### PR TITLE
Fix EGL_KHR_context_flush_control path

### DIFF
--- a/registry.tcl
+++ b/registry.tcl
@@ -524,7 +524,7 @@ extension EGL_KHR_no_config_context {
 extension EGL_KHR_context_flush_control {
     number      102
     flags       public
-    filename    ../gl/extensions/KHR/context_flush_control.txt
+    filename    ../OpenGL/extensions/KHR/KHR_context_flush_control.txt
 }
 extension EGL_ARM_implicit_external_sync {
     number      103


### PR DESCRIPTION
Follow up to cd7c18b163566cd4e3693df6572a00b0635c0997

Note: I couldn't find `regproc.tcl`, so this is untested.