### PR TITLE
Reserving enumerations for EGL_EXT_compositor Bug 16162

### DIFF
--- a/api/egl.xml
+++ b/api/egl.xml
@@ -843,6 +843,14 @@
     <enums namespace="EGL" start="0x3450" end="0x345F" vendor="ANGLE" comment="Reserved for Shannon Woods (Bug 16106)">
             <unused start="0x3450" end="0x345F"/>
     </enums>
+    
+    <enums namespace="EGL" start="0x3460" end="0x346F" vendor="COREAVI" comment="Reserved for Daniel Herring (Bug 16162)">
+        <enum value="0x3460" name="EGL_PRIMARY_COMPOSITOR_CONTEXT_EXT"/>
+        <enum value="0x3461" name="EGL_EXTERNAL_REF_ID_EXT"/>
+        <enum value="0x3462" name="EGL_COMPOSITOR_DROP_NEWEST_FRAME_EXT"/>
+        <enum value="0x3463" name="EGL_COMPOSITOR_KEEP_NEWEST_FRAME_EXT"/>
+        <unused start="0x3464" end="0x346F"/>
+    </enums>
 
 <!-- Please remember that new enumerant allocations must be obtained by
      request to the Khronos API registrar (see comments at the top of this
@@ -853,8 +861,8 @@
 
 <!-- Reservable for future use. To generate a new range, allocate multiples
      of 16 starting at the lowest available point in this block. -->
-    <enums namespace="EGL" start="0x3460" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
-            <unused start="0x3460" end="0x3FFF"/>
+    <enums namespace="EGL" start="0x3470" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
+            <unused start="0x3470" end="0x3FFF"/>
     </enums>
 
     <enums namespace="EGL" start="0x8F70" end="0x8F7F" vendor="HI" comment="For Mark Callow, Khronos bug 4055. Shared with GL.">


### PR DESCRIPTION
This pull request is to reserve a number of EGL enumerates for the extension discussed in Bug 16162. 