### PR TITLE
WIP: Add Display-P3 color space

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #include <EGL/eglplatform.h>
 
-/* Generated on date 20170301 */
+/* Generated on date 20170323 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20170301
+#define EGL_EGLEXT_VERSION 20170323
 
 /* Generated C header for:
  * API: egl
@@ -641,6 +641,16 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint a
 #define EGL_EXT_gl_colorspace_bt2020_pq 1
 #define EGL_GL_COLORSPACE_BT2020_PQ_EXT   0x3340
 #endif /* EGL_EXT_gl_colorspace_bt2020_pq */
+
+#ifndef EGL_EXT_gl_colorspace_display_p3
+#define EGL_EXT_gl_colorspace_display_p3 1
+#define EGL_GL_COLORSPACE_DISPLAY_P3_EXT  0x3363
+#endif /* EGL_EXT_gl_colorspace_display_p3 */
+
+#ifndef EGL_EXT_gl_colorspace_display_p3_linear
+#define EGL_EXT_gl_colorspace_display_p3_linear 1
+#define EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT 0x3362
+#endif /* EGL_EXT_gl_colorspace_display_p3_linear */
 
 #ifndef EGL_EXT_gl_colorspace_scrgb_linear
 #define EGL_EXT_gl_colorspace_scrgb_linear 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -791,7 +791,9 @@
             <unused start="0x3351" end="0x335F"/>
         <enum value="0x3360" name="EGL_CTA861_3_MAX_CONTENT_LIGHT_LEVEL_EXT"/>
         <enum value="0x3361" name="EGL_CTA861_3_MAX_FRAME_AVERAGE_LEVEL_EXT"/>
-            <unused start="0x3362" end="0x339F"/>
+        <enum value="0x3362" name="EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT"/>
+        <enum value="0x3363" name="EGL_GL_COLORSPACE_DISPLAY_P3_EXT"/>
+            <unused start="0x3364" end="0x339F"/>
     </enums>
 
     <enums namespace="EGL" start="0x33A0" end="0x33AF" vendor="ANGLE" comment="Reserved for Shannon Woods (Bug 13175)">
@@ -2096,6 +2098,16 @@
         <extension name="EGL_EXT_gl_colorspace_scrgb_linear" supported="egl">
             <require>
                 <enum name="EGL_GL_COLORSPACE_SCRGB_LINEAR_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_display_p3_linear" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_display_p3" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_DISPLAY_P3_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_image_dma_buf_import" supported="egl">

--- a/extensions/EXT/EGL_EXT_gl_colorspace_display_p3.txt
+++ b/extensions/EXT/EGL_EXT_gl_colorspace_display_p3.txt
@@ -1,0 +1,128 @@
+Name
+
+    EXT_gl_colorspace_display_p3
+
+Name Strings
+
+    EGL_EXT_gl_colorspace_display_p3_linear
+    EGL_EXT_gl_colorspace_display_p3
+
+Contributors
+
+    Courtney Goeltzenleuchter
+    Jesse Hall
+
+Contact
+
+    Courtney Goeltzenleuchter (courtneygo 'at' google.com)
+
+IP Status
+
+    No known IP claims.
+
+Status
+
+    Draft
+
+Version
+
+     Version 1 - Mar 22, 2017
+
+Number
+
+    EGL Extension #118
+
+Dependencies
+
+    These extensions are written against the wording of the EGL 1.5
+    specification (August 27, 2014).
+
+    These extensions require EGL_KHR_gl_colorspace.
+
+Overview
+
+    Applications that want to use the Display-P3 color space (DCI-P3 primaries
+    and linear or sRGB-like transfer function can use this extension to
+    communicate to the platform that it is using the Display-P3 color space.
+    Applications can use built-in sRGB encoding for the nonlinear encoding.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    Accepted as attribute values for EGL_GL_COLORSPACE by
+    eglCreateWindowSurface, eglCreatePbufferSurface and eglCreatePixmapSurface:
+
+    [[ If EGL_EXT_gl_colorspace_display_p3_linear is supported ]]
+
+        EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT         0x3362
+
+    [[ If EGL_EXT_gl_colorspace_bt2020_pq is supported ]]
+
+        EGL_GL_COLORSPACE_DISPLAY_P3_EXT                0x3363
+
+Modifications to the EGL 1.5 Specification
+
+    Insert below text in the 3rd paragraph on page 33 in 3.5.1 "Creating On-
+    Screen Rendering Surfaces, before "The default value of EGL_GL_COLORSPACE
+    is EGL_GL_COLORSPACE_LINEAR.":
+
+    [[ If EGL_EXT_gl_colorspace_display_p3_linear is supported ]]
+
+    If its value is EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT, then a linear
+    Display-P3 color space is assumed, with a corresponding
+    GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING value of GL_LINEAR.
+
+    [[ If EGL_EXT_gl_colorspace_display_p3 is supported ]]
+
+    If its value is EGL_GL_COLORSPACE_DISPLAY_P3_EXT, then a non-linear, sRGB
+    encoded Display-P3 color space is assumed, with a corresponding GL_FRAME-
+    BUFFER_ATTACHMENT_COLOR_ENCODING value of GL_SRGB.
+    Only OpenGL and OpenGL ES contexts which support sRGB rendering must
+    respect requests for EGL_GL_COLORSPACE_SRGB_KHR, and only to sRGB
+    formats supported by the context (normally just SRGB8).
+
+    Modify the 4th paragraph on the same page:
+
+    Note that the EGL_GL_COLORSPACE_SRGB attribute is used only by OpenGL and
+    OpenGL ES contexts supporting sRGB framebuffers. EGL itself does not
+    distinguish multiple colorspace models. Refer to the "sRGB Conversion"
+    sections of the OpenGL 4.4 and OpenGL ES 3.0 specifications for more
+    information.
+
+Errors
+
+    Modify below error in the "Errors" section on page 34:
+
+    "If config does not support the OpenVG colorspace or alpha format at-
+    tributes specified in attrib list (as defined for eglCreatePlatformWindow-
+    Surface), an EGL_BAD_MATCH error is generated."
+
+    To include OpenGL colorspace as well:
+
+    "If config does not support the OpenGL colorspace, the OpenVG colorspace or
+    alpha format attributes specified in attrib list (as defined for eglCreate-
+    PlatformWindowSurface), an EGL_BAD_MATCH error is generated."
+
+Issues
+
+    1. Removed section talking about HDR features, e.g. luminance > 80nits.
+       Do we want to keep that here in anticipation of HDR support in the future?
+
+    2. When creating an EGL surface, what happens when the specified colorspace
+       is not compatible with or supported by the EGLConfig?
+
+       RESOLVED: There is currently no way to query the compatibility of a
+       EGLConfig and colorspace pair. So the only option is to define an error
+       case similar to that of OpenVG colorspace, i.e. if config does not
+       support the colorspace specified in attrib list (as defined for egl-
+       CreateWindowSurface, eglCreatePbufferSurface and eglCreatePixmapSurface),
+       an EGL_BAD_MATCH error is generated.
+
+Revision History
+
+    Version 1, 2017/03/22
+      - Internal revisions
+

--- a/index.php
+++ b/index.php
@@ -310,6 +310,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=117> <a href="extensions/EXT/EGL_EXT_surface_CTA861_3_metadata.txt">EGL_EXT_surface_CTA861_3_metadata</a>
 </li>
+<li value=118> <a href="extensions/EXT/EXT_gl_colorspace_display_p3.txt">EGL_EXT_gl_colorspace_display_p3_linear</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -609,4 +609,9 @@ extension EGL_EXT_surface_CTA861_3_metadta {
     flags       public
     filename    extensions/EXT/EGL_EXT_surface_CTA861_3_metadata.txt
 }
-# Next free extension number: 118
+extension EGL_EXT_surface_CTA861_3_metadta {
+    number      118
+    flags       public
+    filename    extensions/EXT/EGL_EXT_colorspace_display_p3.txt
+}
+# Next free extension number: 119


### PR DESCRIPTION
Adds two enums that to allow applications to specify
that they are using a Display-P3 color space.
[ChangeLog] Add EXT_gl_colorspace_display_p3 extension