### PR TITLE
Add non-linear scRGB extension

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #include <EGL/eglplatform.h>
 
-/* Generated on date 20170406 */
+/* Generated on date 20170621 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -38,7 +38,7 @@ extern "C" {
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20170406
+#define EGL_EGLEXT_VERSION 20170621
 
 /* Generated C header for:
  * API: egl
@@ -660,6 +660,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint a
 #define EGL_EXT_gl_colorspace_display_p3_linear 1
 #define EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT 0x3362
 #endif /* EGL_EXT_gl_colorspace_display_p3_linear */
+
+#ifndef EGL_EXT_gl_colorspace_scrgb
+#define EGL_EXT_gl_colorspace_scrgb 1
+#define EGL_GL_COLORSPACE_SCRGB_EXT       0x3351
+#endif /* EGL_EXT_gl_colorspace_scrgb */
 
 #ifndef EGL_EXT_gl_colorspace_scrgb_linear
 #define EGL_EXT_gl_colorspace_scrgb_linear 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -788,7 +788,7 @@
         <enum value="0x334E" name="EGL_STREAM_CROSS_DISPLAY_NV"/>
         <enum value="0x334F" name="EGL_STREAM_CROSS_SYSTEM_NV"/>
         <enum value="0x3350" name="EGL_GL_COLORSPACE_SCRGB_LINEAR_EXT"/>
-            <unused start="0x3351"/>
+        <enum value="0x3351" name="EGL_GL_COLORSPACE_SCRGB_EXT"/>
         <enum value="0x3352" name="EGL_TRACK_REFERENCES_KHR"/>
             <unused start="0x3353" end="0x335F"/>
         <enum value="0x3360" name="EGL_CTA861_3_MAX_CONTENT_LIGHT_LEVEL_EXT"/>
@@ -2102,6 +2102,11 @@
         <extension name="EGL_EXT_gl_colorspace_bt2020_pq" supported="egl">
             <require>
                 <enum name="EGL_GL_COLORSPACE_BT2020_PQ_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_scrgb" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_SCRGB_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_gl_colorspace_scrgb_linear" supported="egl">

--- a/extensions/EXT/EGL_EXT_gl_colorspace_scrgb.txt
+++ b/extensions/EXT/EGL_EXT_gl_colorspace_scrgb.txt
@@ -1,0 +1,127 @@
+Name
+
+    EXT_gl_colorspace_scrgb
+
+Name Strings
+
+    EGL_EXT_gl_colorspace_scrgb
+
+Contributors
+
+    Courtney Goeltzenleuchter
+    Lauri Hyvarinen
+    Weiwan Liu
+    Arun Swain
+
+Contact
+
+    Courtney Goeltzenleuchter (courtneygo 'at' google.com)
+
+IP Status
+
+    No known IP claims.
+
+Status
+
+    Draft
+
+Version
+
+     Version 1 - June 21, 2017
+
+Number
+
+    EGL Extension #119
+
+Dependencies
+
+    This extension is written against the wording of the EGL 1.5 specification
+    (August 27, 2014).
+
+    This extension requires EGL_KHR_gl_colorspace and EGL_EXT_pixel_format_-
+    float, and interacts with EGL_EXT_surface_SMPTE2086_metadata. This extension
+    is closely related to EGL_EXT_gl_colorspace_scrgb_linear.
+
+Overview
+
+    This extension provides a new color space option, scRGB, for applications to
+    choose from when creating an EGLSurface. The scRGB color space defines a
+    non-linear display referred space. It has the same white point and color
+    primaries as sRGB, and thus is backward-compatible with sRGB. Refer to
+    the IEC 61966-2-2:2003 standard for details on scRGB color space.
+
+    This extension chooses to use floating-point formats for scRGB color space.
+    For each color channel, the floating-point values of 0.0 and 1.0 still
+    correspond to sRGB chromaticities and luminance levels. However, scRGB
+    space allows for color values beyond the range of [0.0, 1.0], and can thus
+    achieve a larger color volume than that of sRGB. As it is display referred,
+    scRGB space makes assumptions of how the floating-point color values should
+    map to luminance levels by the underlying display pipeline. The expected
+    mapping is such that a color value of (1.0, 1.0, 1.0) corresponds to a
+    luminance level of 80 nits on a standardized studio monitor. As the color
+    value per channel goes beyond 1.0 and up to 125.0, the corresponding
+    luminance levels also increase linearly to a maximum of 10000 nits.
+
+    The application is responsible for applying the sRGB transfer function to
+    color values written to or read from a surface with a colorspace of
+    EGL_EXT_gl_colorspace_scrgb.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    Accepted as attribute values for EGL_GL_COLORSPACE by
+    eglCreateWindowSurface, eglCreatePbufferSurface and eglCreatePixmapSurface:
+
+        EGL_GL_COLORSPACE_SCRGB_EXT            0x3351
+
+Modifications to the EGL 1.5 Specification
+
+    Insert below text in the 3rd paragraph on page 33 in 3.5.1 "Creating On-
+    Screen Rendering Surfaces", before "The default value of EGL_GL_COLORSPACE
+    is EGL_GL_COLORSPACE_LINEAR.":
+
+    [[ If EGL_EXT_gl_colorspace_scrgb is supported ]]
+
+    If its value is EGL_GL_COLORSPACE_SCRGB_EXT, then a non-linear scRGB
+    color space is assumed. with a corresponding GL_FRAMEBUFFER_ATTACHMENT_-
+    COLOR_ENCODING value of GL_SRGB. As defined in IEC 61966-2-2:2003, scRGB
+    is a non-linear color space and has the same white point and color primaries as
+    those of sRGB. The application is responsible for applying the appropriate
+    sRGB transfer function when reading or writing to this surface.
+
+
+    Add two paragraphs after the 4th paragraph above:
+
+    When using a floating-point EGL surface with EGL_GL_COLORSPACE_SCRGB_EXT,
+    the display-referred values in the range of (0.0, 0.0, 0.0) to
+    (1.0, 1.0, 1.0) correspond to a luminance range of 0 to 80 nits, which is
+    the same luminance range for sRGB. To achieve a larger dynamic range of up
+    to 10000 nits, the output values can go beyond 1.0 and to a range of
+    [0.0, 125.0] (approximately 7.83 after sRGB transfer function applied) for
+    each channel.
+
+    The effective color gamut and luminance range of the content that extend
+    beyond those of sRGB may be described via EGL_EXT_surface_SMPTE2086_metadata.
+    It is highly recommended to supply such metadata, so the display pipeline
+    may use this information to transform the the colors in a manner that
+    attempts to preserve the creative intent of the color data.
+
+    In the "Errors" section on page 34 in 3.5.1 "Creating On Screen Rendering
+    Surfaces", change the 3rd error definition to:
+
+    * If config does not support the OpenGL colorspace, the OpenVG colorspace or
+      alpha format attributes specified in attrib list (as defined for
+      eglCreatePlatformWindowSurface), an EGL_BAD_MATCH error is generated.
+
+Issues
+
+    No issues so far.
+
+Revision History
+
+    Version 1, 2017/06/21
+    - Initial draft
+

--- a/index.php
+++ b/index.php
@@ -314,6 +314,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=118> <a href="extensions/EXT/EGL_EXT_gl_colorspace_display_p3.txt">EGL_EXT_gl_colorspace_display_p3_linear</a>
 </li>
+<li value=119> <a href="extensions/EXT/EGL_EXT_gl_colorspace_scrgb.txt">EGL_EXT_gl_colorspace_scrgb (non-linear)</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -619,4 +619,9 @@ extension EGL_EXT_gl_colorspace_display_p3 {
     flags       public
     filename    extensions/EXT/EGL_EXT_colorspace_display_p3.txt
 }
+extension EGL_EXT_gl_colorspace_scrgb {
+    number      119
+    flags       public
+    filename    extensions/EXT/EGL_EXT_gl_colorspace_scrgb.txt
+}
 # Next free extension number: 119


### PR DESCRIPTION
This extension adds the ability to mark a buffer as containing
non-linear scRGB content.