### PR TITLE
Remove __NDK_FPABI__ from KHRONOS_APICALL on Android

### DIFF
--- a/api/KHR/khrplatform.h
+++ b/api/KHR/khrplatform.h
@@ -102,8 +102,7 @@
 #elif defined (__SYMBIAN32__)
 #   define KHRONOS_APICALL IMPORT_C
 #elif defined(__ANDROID__)
-#   include <sys/cdefs.h>
-#   define KHRONOS_APICALL __attribute__((visibility("default"))) __NDK_FPABI__
+#   define KHRONOS_APICALL __attribute__((visibility("default")))
 #else
 #   define KHRONOS_APICALL
 #endif


### PR DESCRIPTION
The hardfloat pseudo-ABI is no longer a thing. The Android NDK has
already been shipping this modification for a while.