### PR TITLE
Remove dependency of EGL on Android NDK header.

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -85,8 +85,7 @@ typedef void *EGLNativePixmapType;
 
 #elif defined(__ANDROID__) || defined(ANDROID)
 
-#include <android/native_window.h>
-
+struct ANativeWindow;
 struct egl_native_pixmap_t;
 
 typedef struct ANativeWindow*           EGLNativeWindowType;


### PR DESCRIPTION
This change has been part of the Android NDK since API 18, corresponding
with Android 4.3 Jelly Bean MR2. No projects should depend on
eglplatform.h to include native_window.h.