### PR TITLE
extensions: Add EGL_EXT_explicit_device

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: a732b061e7 $ on $Git commit date: 2017-06-17 23:27:53 +0100 $
+** Khronos $Git commit SHA1: 5e1f541a81 $ on $Git commit date: 2017-08-08 12:53:29 -0400 $
 */
 
 #include <EGL/eglplatform.h>
 
-/* Generated on date 20170627 */
+/* Generated on date 20170808 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: a732b061e7 $ on $Git commit date: 2017-06-17 23:27:53 +0100 $
+** Khronos $Git commit SHA1: 5e1f541a81 $ on $Git commit date: 2017-08-08 12:53:29 -0400 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20170627
+#define EGL_EGLEXT_VERSION 20170808
 
 /* Generated C header for:
  * API: egl
@@ -645,6 +645,10 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint a
 #ifndef EGL_EXT_device_query
 #define EGL_EXT_device_query 1
 #endif /* EGL_EXT_device_query */
+
+#ifndef EGL_EXT_explicit_device
+#define EGL_EXT_explicit_device 1
+#endif /* EGL_EXT_explicit_device */
 
 #ifndef EGL_EXT_gl_colorspace_bt2020_linear
 #define EGL_EXT_gl_colorspace_bt2020_linear 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -2976,5 +2976,10 @@
                 <enum name="EGL_FRONT_BUFFER_EXT"/>
             </require>
         </extension>
+        <extension name="EGL_EXT_explicit_device" supported="egl">
+            <require>
+                <enum name="EGL_DEVICE_EXT"/>
+            </require>
+        </extension>
     </extensions>
 </registry>

--- a/extensions/EXT/EGL_EXT_explicit_device.txt
+++ b/extensions/EXT/EGL_EXT_explicit_device.txt
@@ -1,0 +1,101 @@
+Name
+
+    EXT_explicit_device
+
+Name Strings
+
+    EGL_EXT_explicit_device
+
+Contributors
+
+    Adam Jackson
+    Nicolai Haehnle
+    Daniel Stone
+
+Contacts
+
+    Adam Jackson <ajax@redhat.com>
+
+Status
+
+    Complete
+
+Version
+
+    Version 2, 2017-08-08
+
+Number
+
+    EGL Extension #122
+
+Extension Type
+
+    EGL device extension
+
+Dependencies
+
+    Requires EGL_EXT_platform_base and EGL_EXT_device_base.
+
+    EGL_EXT_platform_device trivially interacts with this extension.
+
+    This extension is written against the EGL 1.5 Specification.
+
+Overview
+
+    A system may support multiple devices and multiple window systems. For
+    example, a Wayland environment may drive multiple GPUs and support both
+    X11 and EGL clients. In order to realize this, the implementation must
+    allow the client to specify both device and platform explicitly.
+
+    The EGL_EXT_platform_device extension enables the client to create a
+    display from a device, but does so by overloading the native_display
+    argument to eglGetPlatformDisplay; the user passes the device as the
+    native display, and presumably the EGL picks a sensible default for the
+    window system.
+
+    EGL_EXT_explicit_device differs by passing the device as an attribute
+    to eglGetPlatformDisplay. This allows the client to name both the device
+    and the platform.
+
+New Types
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    None
+
+Additions to the EGL Specification
+
+    None
+
+New Behavior
+
+    If EGL_DEVICE_EXT is specified as an attribute for eglGetPlatformDisplay,
+    the value of the attribute is interpreted as an EGLDeviceEXT as returned
+    by eglQueryDevicesEXT. The platform will attempt to initialize using
+    exactly the specified device. If the attribute does not name a known
+    EGLDeviceEXT, EGL_BAD_DEVICE_EXT is generated. If the device and platform
+    are not compatible for any reason, EGL_BAD_MATCH is generated.
+
+    If EGL_EXT_platform_device is supported, passing EGL_DEVICE_EXT as an
+    attribute to eglGetPlatformDisplay(EGL_PLATFORM_DEVICE_EXT) generates
+    EGL_BAD_ATTRIBUTE.
+
+Issues
+
+    None
+
+Revision History
+
+    Version 2, 2017-08-08 (Adam Jackson)
+        - Renamed from MESA_platform_device to EXT_explicit_device
+        - Make it an error to use this new attribute in conjunction with
+          EGL_EXT_platform_device
+
+    Version 1, 2017-07-14 (Adam Jackson)
+        - Initial version

--- a/index.php
+++ b/index.php
@@ -308,6 +308,7 @@ include_once("../../assets/static_pages/khr_page_top.php");
 <li value=119> <a href="extensions/EXT/EGL_EXT_gl_colorspace_scrgb.txt">EGL_EXT_gl_colorspace_scrgb (non-linear)</a>
 <li value=120> <a href="extensions/EXT/EXT_image_implicit_sync_control.txt">EGL_EXT_image_implicit_sync_control</a>
 <li value=121> <a href="extensions/EXT/EGL_EXT_bind_to_front.txt">EGL_EXT_bind_to_front</a>
+<li value=122> <a href="extensions/EXT/EGL_EXT_explicit_device.txt">EGL_EXT_explicit_device.txt</a>
 </li>
 </ol>
 

--- a/registry.tcl
+++ b/registry.tcl
@@ -634,4 +634,9 @@ extension EGL_EXT_bind_to_front {
     flags       public
     filename    extensions/EXT/EGL_EXT_bind_to_front.txt
 }
-# Next free extension number: 122
+extension EGL_EXT_explicit_device {
+    number      122
+    flags       public
+    filename    extensions/EXT/EGL_EXT_explicit_device.txt
+}
+# Next free extension number: 123


### PR DESCRIPTION
This adds EGL_DEVICE_EXT as a valid attribute to eglGetPlatformDisplay, to allow the implementation to name both the platform and device explicitly. I'm submitting this as EXT as I think it's strictly superior to EGL_EXT_platform_device and hope non-Mesa vendors adopt it as well.