### PR TITLE
Add EGL platform typedefs for Ozone.

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -92,6 +92,13 @@ typedef struct ANativeWindow*           EGLNativeWindowType;
 typedef struct egl_native_pixmap_t*     EGLNativePixmapType;
 typedef void*                           EGLNativeDisplayType;
 
+#elif defined(USE_OZONE)
+
+/* Chromium-specific */
+typedef intptr_t EGLNativeDisplayType;
+typedef intptr_t EGLNativeWindowType;
+typedef intptr_t EGLNativePixmapType;
+
 #elif defined(__unix__)
 
 /* X11 (tentative)  */


### PR DESCRIPTION
Ozone is a platform abstraction layer used by Chromium:
https://chromium.googlesource.com/chromium/src/+/master/docs/ozone_overview.md