### PR TITLE
Add Ozone section to eglplatform.h

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -92,6 +92,12 @@ typedef struct ANativeWindow*           EGLNativeWindowType;
 typedef struct egl_native_pixmap_t*     EGLNativePixmapType;
 typedef void*                           EGLNativeDisplayType;
 
+#elif defined(USE_OZONE)
+
+typedef intptr_t EGLNativeDisplayType;
+typedef intptr_t EGLNativeWindowType;
+typedef intptr_t EGLNativePixmapType;
+
 #elif defined(__unix__)
 
 /* X11 (tentative)  */


### PR DESCRIPTION
Robert Kroeger added these defines for Ozone to our local Chromium repositories and he's okay with upstreaming them.

With this patch, we should be able to get rid of all local modifications to Chrome's version of eglplatform.h.

@kenrussell to keep you in the loop.