### PR TITLE
Fix use of invalid enum

### DIFF
--- a/extensions/EXT/EGL_EXT_surface_SMPTE2086_metadata.txt
+++ b/extensions/EXT/EGL_EXT_surface_SMPTE2086_metadata.txt
@@ -30,7 +30,7 @@ Status
 
 Version
 
-    Version 6 - Feb 28, 2017
+    Version 7 - Oct 13, 2017
 
 Number
 
@@ -128,7 +128,7 @@ Additions to Chapter "3.5.6 Surface Attributes" of the EGL 1.5 Specification
         EXT, EGL_SMPTE2086_WHITE_POINT_Y_EXT, EGL_SMPTE2086_MAX_LUMINANCE_EXT
         and EGL_SMPTE2086_MIN_LUMINANCE_EXT are EGL_DONT_CARE, which causes the
         hints to be ignored. If value is not in the implementation's supported
-        range for attribute, a EGL_INVALID_VALUE error is generated, and some or
+        range for attribute, a EGL_FALSE error is generated, and some or
         all of the metadata fields are ignored.
 
     Add the following footnote at the end of page 43, and increment all the
@@ -213,7 +213,7 @@ Issues
        what the valid data ranges are for the metadata fields. It is
        implementation dependant, but related standards, such as SMPTE ST 2086,
        can be used as reference. As described in the body, implemetations may
-       generate a EGL_INVALID_VALUE error to notify applications that the input
+       generate a EGL_FALSE error to notify applications that the input
        metadata values are invalid or not supported.
 
 Revision History
@@ -235,4 +235,7 @@ Revision History
 
     Version 6, 2017/02/28
       - Add 'EXT' suffix to 'EGL_METADATA_SCALING'
+
+    Version 7, 2017/10/13
+      - Rename EGL_INVALID_VALUE (which doesn't exist) to EGL_FALSE
 


### PR DESCRIPTION
Accidentally used EGL_INVALID_VALUE which doesn't actually
exist. EGL_FALSE used instead.