### PR TITLE
EGL_MESA_drm_image: fix a couple typos and add a cursor use bit

### DIFF
--- a/api/egl.xml
+++ b/api/egl.xml
@@ -149,6 +149,7 @@
     <enums namespace="EGLDRMBufferUseMESAMask" type="bitmask" comment="EGL_DRM_BUFFER_USE_MESA bits">
         <enum value="0x00000001" name="EGL_DRM_BUFFER_USE_SCANOUT_MESA"/>
         <enum value="0x00000002" name="EGL_DRM_BUFFER_USE_SHARE_MESA"/>
+        <enum value="0x00000004" name="EGL_DRM_BUFFER_USE_CURSOR_MESA"/>
     </enums>
 
     <!-- Should be shared with GL, but aren't aren't since the

--- a/extensions/MESA/EGL_MESA_drm_image.txt
+++ b/extensions/MESA/EGL_MESA_drm_image.txt
@@ -24,7 +24,7 @@ Number
 
 Dependencies
 
-    Reguires EGL 1.4 or later.  This extension is written against the
+    Requires EGL 1.4 or later.  This extension is written against the
     wording of the EGL 1.4 specification.
 
     EGL_KHR_base_image is required.
@@ -134,7 +134,7 @@ Issues
         RESOLVED: The eglQueryImage function has been proposed often,
         but it goes against the EGLImage design.  EGLImages are opaque
         handles to a 2D array of pixels, which can be passed between
-        client APIs.  By referenceing an EGLImage in a client API, the
+        client APIs.  By referencing an EGLImage in a client API, the
         EGLImage target (a texture, a renderbuffer or such) can be
         used to query the attributes of the EGLImage.  We don't have a
         full client API for creating and querying DRM buffers, though,

--- a/extensions/MESA/EGL_MESA_drm_image.txt
+++ b/extensions/MESA/EGL_MESA_drm_image.txt
@@ -16,7 +16,7 @@ Status
 
 Version
 
-    Version 3, November 29, 2010
+    Version 4, November 23, 2017
 
 Number
 
@@ -66,6 +66,7 @@ New Tokens
 
         EGL_DRM_BUFFER_USE_SCANOUT_MESA		0x0001
         EGL_DRM_BUFFER_USE_SHARE_MESA		0x0002
+        EGL_DRM_BUFFER_USE_CURSOR_MESA	0x0004
 
     Accepted in the <target> parameter of eglCreateImageKHR:
 
@@ -89,13 +90,16 @@ Additions to the EGL 1.4 Specification:
     extension is EGL_DRM_BUFFER_FORMAT_ARGB32_MESA, where each pixel
     is a CPU-endian, 32-bit quantity, with alpha in the upper 8 bits,
     then red, then green, then blue.  The bit values accepted by
-    EGL_DRM_BUFFER_USE_MESA are EGL_DRM_BUFFER_USE_SCANOUT_MESA and
-    EGL_DRM_BUFFER_USE_SHARE_MESA.  EGL_DRM_BUFFER_USE_SCANOUT_MESA
-    requests that the created EGLImage should be usable as a scanout
-    buffer with the DRM kernel modesetting API.  The
-    EGL_DRM_BUFFER_USE_SHARE_MESA bit requests that the EGLImage can
-    be shared with other processes by passing the underlying DRM
-    buffer name.
+    EGL_DRM_BUFFER_USE_MESA are EGL_DRM_BUFFER_USE_SCANOUT_MESA,
+    EGL_DRM_BUFFER_USE_SHARE_MESA and EGL_DRM_BUFFER_USE_CURSOR_MESA.
+    EGL_DRM_BUFFER_USE_SCANOUT_MESA requests that the created EGLImage
+    should be usable as a scanout buffer with the DRM kernel
+    modesetting API.  EGL_DRM_BUFFER_USE_SHARE_MESA requests that the
+    EGLImage can be shared with other processes by passing the
+    underlying DRM buffer name.  EGL_DRM_BUFFER_USE_CURSOR_MESA
+    requests that the image must be usable as a cursor with KMS.  When
+    EGL_DRM_BUFFER_USE_CURSOR_MESA is set, width and height must both
+    be 64.
 
     To create a process local handle or a global DRM name for a
     buffer, call
@@ -149,3 +153,5 @@ Revision History
         some of the original discussion in the issues section.
     Version 3, November 29, 2010 (Jon Leech)
         Fix typo.
+    Version 4, November 23, 2017 (Kristian Høgsberg)
+        Fix typos, add EGL_DRM_BUFFER_USE_CURSOR_MESA


### PR DESCRIPTION
This pulls in the Mesa changes from Kristian Høgsberg (@krh) and Nicolas Kaiser (@nikai3d)

https://cgit.freedesktop.org/mesa/mesa/commit/?id=e5169e9615e8391ea369415b356168717b8f7be0
https://cgit.freedesktop.org/mesa/mesa/commit/?id=ae5776c41f12515bb73c07ee2a0aed56cdd1a1ef