### PR TITLE
Add extension EGL_EXT_image_gl_colorspace

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 32dd280a66 $ on $Git commit date: 2017-11-23 11:41:55 -0800 $
+** Khronos $Git commit SHA1: feaaeb19e1 $ on $Git commit date: 2018-02-26 20:49:02 -0800 $
 */
 
 #include <EGL/eglplatform.h>
 
-/* Generated on date 20171123 */
+/* Generated on date 20180228 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 32dd280a66 $ on $Git commit date: 2017-11-23 11:41:55 -0800 $
+** Khronos $Git commit SHA1: feaaeb19e1 $ on $Git commit date: 2018-02-26 20:49:02 -0800 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20171123
+#define EGL_EGLEXT_VERSION 20180228
 
 /* Generated C header for:
  * API: egl
@@ -762,6 +762,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDmaBufFormatsEXT (EGLDisplay dpy, EGLint m
 EGLAPI EGLBoolean EGLAPIENTRY eglQueryDmaBufModifiersEXT (EGLDisplay dpy, EGLint format, EGLint max_modifiers, EGLuint64KHR *modifiers, EGLBoolean *external_only, EGLint *num_modifiers);
 #endif
 #endif /* EGL_EXT_image_dma_buf_import_modifiers */
+
+#ifndef EGL_EXT_image_gl_colorspace
+#define EGL_EXT_image_gl_colorspace 1
+#define EGL_GL_COLORSPACE_DEFAULT_EXT     0x314D
+#endif /* EGL_EXT_image_gl_colorspace */
 
 #ifndef EGL_EXT_image_implicit_sync_control
 #define EGL_EXT_image_implicit_sync_control 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -499,8 +499,9 @@
         <enum value="0x3146" name="EGL_SYNC_NATIVE_FENCE_SIGNALED_ANDROID"/>
         <enum value="0x3147" name="EGL_FRAMEBUFFER_TARGET_ANDROID"/>
             <unused start="0x3148" end="0x314B"/>
-        <enum value="0x314C"     name="EGL_FRONT_BUFFER_AUTO_REFRESH_ANDROID"/>
-            <unused start="0x314D" end="0x314F"/>
+        <enum value="0x314C" name="EGL_FRONT_BUFFER_AUTO_REFRESH_ANDROID"/>
+        <enum value="0x314D" name="EGL_GL_COLORSPACE_DEFAULT_EXT"/>
+            <unused start="0x314E" end="0x314F"/>
     </enums>
 
     <enums namespace="EGL" start="0x3150" end="0x315F" vendor="NOK" comment="Reserved for Robert Palmer (Khronos bug 5368)">
@@ -2260,6 +2261,12 @@
                 <enum name="EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT"/>
                 <command name="eglQueryDmaBufFormatsEXT"/>
                 <command name="eglQueryDmaBufModifiersEXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_image_gl_colorspace" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE"/>
+                <enum name="EGL_GL_COLORSPACE_DEFAULT_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_multiview_window" supported="egl">

--- a/extensions/EXT/EGL_EXT_image_gl_colorspace.txt
+++ b/extensions/EXT/EGL_EXT_image_gl_colorspace.txt
@@ -1,0 +1,135 @@
+Name
+
+    EXT_image_gl_colorspace
+
+Name Strings
+
+    EGL_EXT_image_gl_colorspace
+
+Contributors
+
+    Jesse Hall, Google
+    Philip Rideout, Google
+    Mohan Maiya, Qualcomm
+    Jan-Harald Fredriksen, ARM
+
+Contact
+
+    Krzysztof Kosiński, Google (krzysio 'at' google.com)
+
+Status
+
+    Complete
+
+Version
+
+    Version 9, February 26, 2018
+
+Number
+
+    EGL Extension #125
+
+Dependencies
+
+    Written against the EGL 1.5 specification.
+
+    Can be supported on EGL 1.4 provided that EGL_KHR_gl_colorspace is
+    implemented, as well as either EGL_KHR_image or EGL_KHR_image_base.
+
+    Interacts with the OES_EGL_image_external specification.
+
+Overview
+
+    This extension relaxes the restriction that only the eglCreate*Surface
+    functions can accept the EGL_GL_COLORSPACE attribute. With this change,
+    eglCreateImage can also accept this attribute.
+
+New Tokens
+
+    EGL_GL_COLORSPACE_DEFAULT_EXT          0x314D
+
+New Procedures and Functions
+
+    None.
+
+Additions to the EGL 1.5 Specification
+
+    Add to table 3.11 on page 75:
+
+   "Attribute             Type    Description
+    --------------------  ----    -----------
+    EGL_GL_COLORSPACE     enum    Color space for OpenGL and OpenGL ES"
+
+
+    Add the following paragraph to the end of section 3.9, "EGLImage
+    Specification and Management" on page 77:
+
+   "EGL_GL_COLORSPACE specifies the color space used by OpenGL and OpenGL
+    ES when rendering to the image, or sampling from the image. It has the
+    same meaning as when used with eglCreatePlatformWindowSurface, with the
+    exception that its default value is EGL_GL_COLORSPACE_DEFAULT_EXT. This
+    means that the color space should not be overriden. For example, if an
+    image is created from an existing OpenGL texture, then
+    GL_COLORSPACE_DEFAULT_EXT means that the original color space should be
+    preserved."
+
+
+    Add the following paragraphs to the "Errors" subsection in section 3.9
+    on page 76:
+    
+   "If EGL_GL_COLORSPACE is not one of the legal values, the error
+    EGL_BAD_PARAMETER is generated."
+
+   "If ctx specifies a GL context that does not support creating an EGLImage
+    with the given value for EGL_GL_COLORSPACE, EGL_BAD_MATCH error is
+    generated."
+
+
+Interaction with OES_EGL_image_external:
+
+    The first sentence in the second to last paragraph in section 3.7.14
+    should be changed from:
+
+   "Sampling an external texture will return an RGBA vector in the same
+    colorspace as the source image."
+
+    to:
+
+   "Sampling an external texture will return an RGBA vector in the same color
+    space as the source image, unless the image's EGL_GL_COLORSPACE attribute
+    results in sRGB encoding as described in EGL_KHR_image_gl_colorspace."
+
+    The three parenthetical sentences in this same paragraph should be
+    simplified since they partially conflict with existing language in the
+    ES30 specification. Change them from:
+
+   "(But these RGB values will be in the same colorspace as the
+    original image.  Colorspace here includes the linear or non-linear
+    encoding of the samples. For example, if the original image is in the
+    sRGB color space then the RGB value returned by the sampler will also
+    be sRGB, and if the original image is stored in ITU-R Rec. 601 YV12
+    then the RGB value returned by the sampler will be an RGB value in the
+    ITU-R Rec. 601 colorspace.)"
+
+    to:
+
+   "(For example, if the original image is stored in ITU-R Rec. 601 YV12
+    then the RGB value returned by the sampler will be an RGB value in the
+    ITU-R Rec. 601 colorspace.)"
+
+
+Issues
+
+Revision History
+
+      Rev.  Date      Author    Changes
+      ----  --------  --------  -----------------------------------------
+      1     11/22/17  philip    Initial draft
+      2     12/8/17   philip    Add note about OES_EGL_image_external
+      3     12/11/17  philip    Changed from KHR to EXT.
+      4     12/15/17  philip    Add diffs against the EGL 1.5 specification.
+      5     12/20/17  philip    Add EGL_GL_COLORSPACE_DEFAULT_EXT.
+      6     1/2/18    philip    Updated changes to OES_EGL_image_external.
+      7     1/2/18    philip    Tweaked the changes to OES_EGL_image_external.
+      8     2/2/18    philip    Add value for EGL_GL_COLORSPACE_DEFAULT_EXT.
+      9     2/26/18   krzysio   Update contact information, finalize.

--- a/registry.tcl
+++ b/registry.tcl
@@ -649,4 +649,9 @@ extension EGL_NV_context_priority_realtime {
     flags       public
     filename    extensions/NV/EGL_NV_context_priority_realtime.txt
 }
-# Next free extension number: 125
+extension EGL_EXT_image_gl_colorspace {
+    number      125
+    flags       public
+    filename    extensions/EXT/EGL_EXT_image_gl_colorspace.txt
+}
+# Next free extension number: 126


### PR DESCRIPTION
This is a minimal extension that allows one to override the color space of an EGLImage. This is mainly intended to support creating sRGB images from AHardwareBuffers on Android. The extension was already discussed and approved by Khronos OpenGL ES and EGL working groups.