### PR TITLE
Allow `__APPLE__` platforms to build for X11

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -77,7 +77,7 @@ typedef HDC     EGLNativeDisplayType;
 typedef HBITMAP EGLNativePixmapType;
 typedef HWND    EGLNativeWindowType;
 
-#elif defined(__APPLE__) || defined(__WINSCW__) || defined(__SYMBIAN32__)  /* Symbian */
+#elif defined(__WINSCW__) || defined(__SYMBIAN32__)  /* Symbian */
 
 typedef int   EGLNativeDisplayType;
 typedef void *EGLNativeWindowType;
@@ -98,7 +98,7 @@ typedef intptr_t EGLNativeDisplayType;
 typedef intptr_t EGLNativeWindowType;
 typedef intptr_t EGLNativePixmapType;
 
-#elif defined(__unix__)
+#elif defined(__unix__) || defined(__APPLE__)
 
 /* X11 (tentative)  */
 #include <X11/Xlib.h>


### PR DESCRIPTION
This push to Khronos the change done by Julien Isorce in Mesa commit [7d642442d9339e5b65c30802c44091816cdf18be "egl: use unix defines on osx
with clang"](https://cgit.freedesktop.org/mesa/mesa/commit/?id=7d642442d9339e5b65c30802c44091816cdf18be)

Bug was reported to Khronos in [bug 1356](https://www.khronos.org/bugzilla/show_bug.cgi?id=1356) after being reported in the Mesa bug tracker in [bug 90249](https://bugs.freedesktop.org/show_bug.cgi?id=90249).