### PR TITLE
Define Wayland native platform types

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -83,6 +83,12 @@ typedef int   EGLNativeDisplayType;
 typedef void *EGLNativeWindowType;
 typedef void *EGLNativePixmapType;
 
+#elif defined(WL_EGL_PLATFORM)
+
+typedef struct wl_display     *EGLNativeDisplayType;
+typedef struct wl_egl_pixmap  *EGLNativePixmapType;
+typedef struct wl_egl_window  *EGLNativeWindowType;
+
 #elif defined(__ANDROID__) || defined(ANDROID)
 
 struct ANativeWindow;


### PR DESCRIPTION
This pushes to Khronos the changes done by Kristian Høgsberg in Mesa
commits [04c5cc5b8bec1f34f2405b08fd0d9ed6bd70ea61 "eglplatform.h: Define
Wayland native platform types"](https://cgit.freedesktop.org/mesa/mesa/commit/?id=04c5cc5b8bec1f34f2405b08fd0d9ed6bd70ea61) and
[c0f8c9911c82c576cdd82dabad4a2370ac53565c "wayland-egl: Update to
wayland-egl.h changes, drop struct wl_egl_display"](https://cgit.freedesktop.org/mesa/mesa/commit/?id=c0f8c9911c82c576cdd82dabad4a2370ac53565c).

Note that WL_EGL_PLATFORM is defined by the Wayland EGL implementation,
such as [the one in the Wayland project](https://cgit.freedesktop.org/wayland/wayland/tree/egl/wayland-egl-core.h#n34).