### PR TITLE
genheaders: fix time.clock() deprecation warning

### DIFF
--- a/api/genheaders.py
+++ b/api/genheaders.py
@@ -75,10 +75,10 @@ if __name__ == '__main__':
 startTime = None
 def startTimer():
     global startTime
-    startTime = time.clock()
+    startTime = time.process_time()
 def endTimer(msg):
     global startTime
-    endTime = time.clock()
+    endTime = time.process_time()
     if (timeit):
         write(msg, endTime - startTime)
         startTime = None


### PR DESCRIPTION
> genheaders.py:78: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead

I chose [`time.process_time()`](https://docs.python.org/3/library/time.html#time.process_time) as I assume the CPU time is what we care about when timing the code, not the wall time that [`time.perf_counter()`](https://docs.python.org/3/library/time.html#time.perf_counter) returns (which includes sleeping and other processes on the system).