### PR TITLE
Add EGL 1.5 reference pages, and additions to existing reference pages.

### DIFF
--- a/sdk/docs/man/eglBindAPI.xml
+++ b/sdk/docs/man/eglBindAPI.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglBindAPI">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -48,6 +48,7 @@
             <function>eglGetCurrentDisplay</function>,
             <function>eglGetCurrentSurface</function>,
             <function>eglMakeCurrent</function>,
+            <function>eglSwapInterval</function>,
             <function>eglWaitClient</function>, and
             <function>eglWaitNative</function>.
         </para>
@@ -113,6 +114,7 @@
             <citerefentry><refentrytitle>eglGetCurrentSurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglMakeCurrent</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglQueryAPI</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglSwapInterval</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglWaitClient</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglWaitNative</refentrytitle></citerefentry>
         </para>

--- a/sdk/docs/man/eglChooseConfig.xml
+++ b/sdk/docs/man/eglChooseConfig.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglChooseConfig">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -404,8 +404,9 @@
                     The default value is zero.
                 </para>
                 <para>
-                    Most imlementations do not support overlay or
-                    underlay planes (buffer levels other than zero).
+                    Most platforms do not support buffer levels other than
+                    zero. The behavior of windows placed in overlay and
+                    underlay planes depends on the underlying platform.
                 </para>
                 </listitem>
             </varlistentry>

--- a/sdk/docs/man/eglChooseConfig.xml
+++ b/sdk/docs/man/eglChooseConfig.xml
@@ -133,8 +133,7 @@
                     is zero.
                 </para>
                 <para>
-                    The alpha mask buffer is used only by OpenGL and
-                    OpenGL ES client APIs.
+                    The alpha mask buffer is used only by OpenVG.
                 </para>
                 </listitem>
             </varlistentry>

--- a/sdk/docs/man/eglClientWaitSync.xml
+++ b/sdk/docs/man/eglClientWaitSync.xml
@@ -1,0 +1,161 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglClientWaitSync">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglClientWaitSync</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglClientWaitSync</refname>
+        <refpurpose>
+            Wait in the client for a sync object to be signalled
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+            <funcdef>EGLint <function>eglClientWaitSync</function></funcdef>
+            <paramdef>(EGLDisplay <parameter>display</parameter></paramdef>
+            <paramdef>EGLSync <parameter>sync</parameter></paramdef>
+            <paramdef>EGLint <parameter>flags</parameter></paramdef>
+            <paramdef>EGLTime <parameter>timeout</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>display</parameter></term>
+                <listitem><para>
+                    Specifies the <acronym>EGL</acronym> display connection.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>sync</parameter></term>
+                <listitem><para>
+                    Specifies the sync object to wait on.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>flags</parameter></term>
+                <listitem><para>
+                    Specifies flags controlling wait behavior.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>timeout</parameter></term>
+                <listitem><para>
+                    Specifies wait timeout interval.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <function>eglClientWaitSync</function> blocks the calling thread
+            until the specified sync object <parameter>sync</parameter> is
+            signaled, or until <parameter>timeout</parameter> nanoseconds
+            have passed.
+        </para>
+        <para>
+            More than one <function>eglClientWaitSync</function> may be
+            outstanding on the same <parameter>sync</parameter> at any given
+            time. When there are multiple threads blocked on the same
+            <parameter>sync</parameter> and the sync object is signaled, all
+            such threads are released, but the order in which they are
+            released is not defined.
+        </para>
+        <para>
+            If the value of <parameter>timeout</parameter> is zero, then
+            <function>eglClientWaitSync</function> simply tests the current
+            status of <parameter>sync</parameter>. If the value of
+            <parameter>timeout</parameter> is the special value
+            <constant>EGL_FOREVER</constant>, then
+            <function>eglClientWaitSync</function> does not time out. For
+            all other values, <parameter>timeout</parameter> is adjusted to
+            the closest value allowed by the implementation-dependent
+            timeout accuracy, which may be substantially longer than one
+            nanosecond.
+        </para>
+        <para>
+            <function>eglClientWaitSync</function> returns one of three
+            status values describing the reason for returning. A return
+            value of <constant>EGL_TIMEOUT_EXPIRED</constant> indicates that
+            the specified timeout period expired before
+            <parameter>sync</parameter> was signaled, or if
+            <parameter>timeout</parameter> is zero, indicates that
+            <parameter>sync</parameter> is not signaled. A return value of
+            <constant>EGL_CONDITION_SATISFIED</constant> indicates that
+            <parameter>sync</parameter> was signaled before the timeout
+            expired, which includes the case when
+            <parameter>sync</parameter> was already signaled when
+            <function>eglClientWaitSync</function> was called. If an error
+            occurs then an error is generated and
+            <constant>EGL_FALSE</constant> is returned.
+        </para>
+        <para>
+            If the sync object being blocked upon will not be signaled in
+            finite time (for example, by an associated fence command issued
+            previously, but not yet flushed to the graphics pipeline), then
+            <function>eglClientWaitSync</function> may wait forever. To help
+            prevent this behavior, if the
+            <constant>EGL_SYNC_FLUSH_COMMANDS_BIT</constant> bit is set in
+            <parameter>flags</parameter>, and <parameter>sync</parameter> is
+            unsignaled when <function>eglClientWaitSync</function> is
+            called, then the equivalent of Flush() will be performed for the
+            current API context (i.e., the context returned by
+            <function>eglGetCurrentContext</function>) before blocking on
+            <parameter>sync</parameter>. If no context is current for the
+            bound API, the <constant>EGL_SYNC_FLUSH_COMMANDS_BIT</constant>
+            bit is ignored.
+        </para>
+        <para>
+            Note: the simple Flush behavior defined by
+            <constant>EGL_SYNC_FLUSH_COMMANDS_BIT</constant> will not help
+            when waiting for a fence command issued in a different context's
+            command stream. Applications which block on a fence sync object
+            must take additional steps to ensure that the context from which
+            the associated fence command was issued has flushed that command
+            to the graphics pipeline.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            <function>eglClientWaitSync</function> returns
+            <constant>EGL_FALSE</constant> on failure.
+        </para>
+        <para>
+            If <parameter>sync</parameter> is not a valid sync object for
+            <parameter>display</parameter>, an
+            <constant>EGL_BAD_PARAMETER</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>display</parameter> does not match the
+            <type>EGLDisplay</type> passed to
+            <function>eglCreateSync</function> when
+            <parameter>sync</parameter> was created, the behaviour is
+            undefined.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglClientWaitSync</function> is available only if the
+            EGL version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>eglCreateSync</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglGetCurrentContext</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglWaitSync</refentrytitle></citerefentry>,
+            <function>glFinish</function>,
+            <function>vgFinish</function>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/eglCreateContext.xml
+++ b/sdk/docs/man/eglCreateContext.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreateContext">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -101,111 +101,112 @@
         </para>
         <variablelist>
             <varlistentry>
-                <term><constant>EGL_CONTEXT_CLIENT_VERSION</constant></term>
+                <term><constant>EGL_CONTEXT_MAJOR_VERSION</constant></term>
                 <listitem><para>
-                    Must be followed by an integer that determines which
-                    version of an OpenGL ES context to create. A value
-                    of 1 specifies creation of an OpenGL ES 1.x context.
-                    An attribute value of 2 specifies creation of an
-                    OpenGL ES 2.x context. The default value is 1. This
-                    attribute can only be specified when creating a
-                    OpenGL ES context (e.g. when the current rendering
-                    API is <constant>EGL_OPENGL_ES_API</constant>).
+                    Must be followed by an integer specifying the requested
+                    major version of an OpenGL or OpenGL ES context. The
+                    default value is 1. This attribute is an alias of the
+                    older <constant>EGL_CONTEXT_CLIENT_VERSION</constant>,
+                    and the tokens may be used interchangeably.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_CONTEXT_MINOR_VERSION</constant></term>
+                <listitem><para>
+                    Must be followed by an integer specifying the requested
+                    minor version of an OpenGL or OpenGL ES context. The
+                    default value is 0.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_CONTEXT_OPENGL_PROFILE_MASK</constant></term>
+                <listitem><para>
+                    Must be followed by an integer bitmask specifying the
+                    <firstterm>profile</firstterm> of an OpenGL context.
+                    Bits which may be set include
+                    <constant>EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT</constant>
+                    for a core profile and
+                    <constant>EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT</constant>
+                    for a compatibility profile. The default value is
+                    <constant>EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT</constant>.
+                    All OpenGL 3.2 and later implementations are required to
+                    implement the core profile, but implementation of the
+                    compatibility profile is optional.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_CONTEXT_OPENGL_DEBUG</constant></term>
+                <listitem><para>
+                    Must be followed by <constant>EGL_TRUE</constant>,
+                    specifying that an OpenGL or OpenGL ES <firstterm>debug
+                    context</firstterm> should be created, or
+                    <constant>EGL_FALSE</constant>, if a non-debug context
+                    should be created. The default value is
+                    <constant>EGL_FALSE</constant>.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE</constant></term>
+                <listitem><para>
+                    Must be followed by <constant>EGL_TRUE</constant>,
+                    specifying that a
+                    <firstterm>forward-compatible</firstterm> OpenGL context
+                    should be created, or <constant>EGL_FALSE</constant>, if
+                    a non-forward-compatible context should be created. The
+                    default value is <constant>EGL_FALSE</constant>.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_CONTEXT_OPENGL_ROBUST_ACCESS</constant></term>
+                <listitem><para>
+                    Must be followed by <constant>EGL_TRUE</constant>,
+                    specifying that an OpenGL or OpenGL ES context
+                    supporting <firstterm>robust buffer access</firstterm>
+                    should be created, or <constant>EGL_FALSE</constant>, if
+                    a non-robust context should be created. The default
+                    value is <constant>EGL_FALSE</constant>.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY</constant></term>
+                <listitem><para>
+                    Must be followed by
+                    <constant>EGL_LOSE_CONTEXT_ON_RESET</constant>,
+                    specifying that an OpenGL or OpenGL ES context with
+                    reset notification behavior
+                    <constant>GL_LOSE_CONTEXT_ON_RESET_ARB</constant> should
+                    be created, or
+                    <constant>EGL_NO_RESET_NOTIFICATION</constant>,
+                    specifying that an OpenGL or OpenGL ES context with
+                    reset notification behavior
+                    <constant>GL_NO_RESET_NOTIFICATION_ARB</constant> should
+                    be created, as described by the
+                    <constant>GL_ARB_robustness</constant> extension.
+                </para><para>
+                    If the
+                    <constant>EGL_CONTEXT_OPENGL_ROBUST_ACCESS</constant>
+                    attribute is not set to <constant>EGL_TRUE</constant>,
+                    context creation will not fail, but the resulting
+                    context may not support robust buffer access, and
+                    therefore may not support the requested reset
+                    notification strategy The default value for
+                    <constant>EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY</constant>
+                    is <constant>EGL_NO_RESET_NOTIFICATION</constant> .
                 </para></listitem>
             </varlistentry>
         </variablelist>
-    </refsect1>
-    <refsect1 xml:id="notes"><title>Notes</title>
         <para>
-            The current rendering API is only respected if the EGL
-            version is 1.2 or greater. Otherwise, an OpenGL ES context
-            will always be created.
-        </para>
-        <para>
-            The <constant>EGL_CONTEXT_CLIENT_VERSION</constant>
-            attribute is only supported if the EGL version is 1.3 or
-            greater.
-        </para>
-        <para>
-            A <firstterm>process</firstterm> is a single execution environment,
-            implemented in a single address space, consisting of one or more threads.
-        </para>
-        <para>
-            A <firstterm>thread</firstterm> is one of a set of subprocesses that
-            share a single address space, but maintain separate program counters,
-            stack spaces, and other related global data.
-            A thread is the only member of its subprocess group is equivalent to a
-            process.
+            There are many possible interactions between requested OpenGL
+            and OpenGL ES context creation attributes, depending on the API
+            versions and extensions supported by the implementation. These
+            interactions are described in detail in the EGL 1.5
+            Specification, but are not listed here for compactness. The
+            requested attributes may not be able to be satisfied, but
+            context creation may still succeed. Applications should ensure
+            that the OpenGL or OpenGL ES contexts supports needed features
+            before using them, by determining the actual context version,
+            supported extensions, and supported context flags using runtime
+            queries.
         </para>
     </refsect1>
-    <refsect1 xml:id="errors"><title>Errors</title>
-        <para>
-            <constant>EGL_NO_CONTEXT</constant> is returned if creation of
-            the context fails.
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if the
-            current rendering API is <constant>EGL_NONE</constant> (this
-            can only arise in an EGL implementation which does not
-            support OpenGL ES, prior to the first call to
-            <function>eglBindAPI</function>).
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if the
-            server context state for
-            <parameter>share_context</parameter> exists in an address
-            space which cannot be shared with the newly created context,
-            if <parameter>share_context</parameter> was created on a
-            different display than the one referenced by
-            <parameter>config</parameter>, or if the contexts are
-            otherwise incompatible.
-        </para>
-        <para>
-            <constant>EGL_BAD_DISPLAY</constant> is generated if
-            <parameter>display</parameter> is not an EGL display connection.
-        </para>
-        <para>
-            <constant>EGL_NOT_INITIALIZED</constant> is generated if
-            <parameter>display</parameter> has not been initialized.
-        </para>
-        <para>
-            <constant>EGL_BAD_CONFIG</constant> is generated if
-            <parameter>config</parameter> is not an EGL frame buffer
-            configuration, or does not support the current rendering
-            API. This includes requesting creation of an OpenGL ES 1.x
-            context when the <constant>EGL_RENDERABLE_TYPE</constant>
-            attribute of <parameter>config</parameter> does not contain
-            <constant>EGL_OPENGL_ES_BIT</constant>, or creation of an
-            OpenGL ES 2.x context when the attribute does not contain
-            <constant>EGL_OPENGL_ES2_BIT</constant>.
-        </para>
-        <para>
-            <constant>EGL_BAD_CONTEXT</constant> is generated if
-            <parameter>share_context</parameter> is not an EGL rendering
-            context of the same client API type as the newly created
-            context and is not <constant>EGL_NO_CONTEXT</constant>.
-        </para>
-        <para>
-            <constant>EGL_BAD_ATTRIBUTE</constant> is generated if
-            <parameter>attrib_list</parameter> contains an invalid
-            context attribute or if an attribute is not recognized or
-            out of range. Note that attribute
-            <constant>EGL_CONTEXT_CLIENT_VERSION</constant> is
-            only valid when the current rendering API is
-            <constant>EGL_OPENGL_ES_API</constant>.
-        </para>
-        <para>
-            <constant>EGL_BAD_ALLOC</constant> is generated if there are not
-            enough resources to allocate the new context.
-        </para>
-    </refsect1>
-    <refsect1 xml:id="seealso"><title>See Also</title>
-        <para>
-            <citerefentry><refentrytitle>eglDestroyContext</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>eglChooseConfig</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>eglGetConfigs</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>eglMakeCurrent</refentrytitle></citerefentry>
-        </para>
-    </refsect1>
-    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
 </refentry>

--- a/sdk/docs/man/eglCreateImage.xml
+++ b/sdk/docs/man/eglCreateImage.xml
@@ -1,0 +1,624 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreateImage">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglCreateImage</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglCreateImage</refname>
+        <refpurpose>
+            Create a new <type>EGLImage</type> object
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+            <funcdef>EGLImage <function>eglCreateImage</function></funcdef>
+            <paramdef>(EGLDisplay <parameter>display</parameter></paramdef>
+            <paramdef>EGLContext <parameter>context</parameter></paramdef>
+            <paramdef>EGLenum <parameter>target</parameter></paramdef>
+            <paramdef>EGLClientBuffer <parameter>buffer</parameter></paramdef>
+            <paramdef>const EGLAttrib *<parameter>attrib_list</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>display</parameter></term>
+                <listitem><para>
+                    Specifies the <acronym>EGL</acronym> display connection.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>sync</parameter></term>
+                <listitem><para>
+                    Specifies the client API context for which the image is
+                    created.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>target</parameter></term>
+                <listitem><para>
+                    Specifies the type of resource used as the image source.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>buffer</parameter></term>
+                <listitem><para>
+                    Specifies the resource to be used as the image source.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>attrib_list</parameter></term>
+                <listitem><para>
+                    Specifies attributes used to select sub-sectins of the
+                    resource to be used as the image source.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <function>eglCreateImage</function> is used to create an
+            <type>EGLImage</type> object from an existing image resource
+            <parameter>buffer</parameter>. <parameter>display</parameter>
+            specifies the EGL display used for this operation.
+            <parameter>context</parameter> specifies the EGL client API
+            context used for this operation, or
+            <constant>EGL_NO_CONTEXT</constant> if a client API context is
+            not required. <parameter>target</parameter> specifies the type
+            of resource being used as the <type>EGLImage</type> source
+            (examples include two-dimensional textures in OpenGL ES contexts
+            and <type>VGImage</type> objects in OpenVG contexts).
+            <parameter>buffer</parameter> is the name (or handle) of a
+            resource to be used as the <type>EGLImage</type> source, cast
+            into the type <type>EGLClientBuffer</type>.
+            <parameter>attrib_list</parameter> is a list of attribute-value
+            pairs which is used to select sub-sections of
+            <parameter>buffer</parameter> for use as the
+            <type>EGLImage</type> source, such as mipmap levels for OpenGL
+            ES texture map resources, as well as behavioral options, such as
+            whether to preserve pixel data during creation. If
+            <parameter>attrib_list</parameter> is
+            non-<constant>NULL</constant>, the last attribute specified in
+            the list must be <constant>EGL_NONE</constant>.
+        </para>
+        <para>
+            The resource specified by <parameter>display</parameter>,
+            <parameter>context</parameter>, <parameter>target</parameter>,
+            <parameter>buffer</parameter>, and
+            <parameter>attrib_list</parameter> must not itself be an
+            <type>EGLImage</type> sibling, or bound to a pbuffer
+            <type>EGLSurface</type> resource
+            (<function>eglBindTexImage</function>,
+            <function>eglCreatePbufferFromClientBuffer</function>).
+        </para>
+        <para>
+            Values accepted for <parameter>target</parameter> are shown in
+            table <xref linkend="tab-imagetarget"/>.
+        </para>
+        <table frame="all" xml:id="tab-imagetarget">
+            <title>
+                Legal values for <function>eglCreateImage</function> <parameter>target</parameter>
+            </title>
+            <tgroup cols="2" align="left" colsep="1" rowsep="1">
+                <thead>
+                    <row>
+                        <entry><parameter>target</parameter></entry>
+                        <entry>Notes</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_2D</constant></entry>
+                        <entry>Used for GL 2D texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X</constant></entry>
+                        <entry>Used for the +X face of GL cubemap texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X</constant></entry>
+                        <entry>Used for the -X face of GL cubemap texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y</constant></entry>
+                        <entry>Used for the +Y face of GL cubemap texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y</constant></entry>
+                        <entry>Used for the -Y face of GL cubemap texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z</constant></entry>
+                        <entry>Used for the +Z face of GL cubemap texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z</constant></entry>
+                        <entry>Used for the -Z face of GL cubemap texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_3D</constant></entry>
+                        <entry>Used for OpenGL and OpenGL ES 3D texture images</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_RENDERBUFFER</constant></entry>
+                        <entry>Used for OpenGL and OpenGL ES renderbuffer images</entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+        <para>
+            Attribute names accepted in <parameter>attrib_list</parameter>
+            are shown in table <xref linkend="tab-imageattr"/>, together
+            with the <parameter>target</parameter> for which each attribute
+            name is valid, and the default value used for each attribute if
+            it is not included in <parameter>attrib_list</parameter>.
+        </para>
+        <table frame="all" xml:id="tab-imageattr">
+            <title>
+                Legal attributes for <function>eglCreateImage</function>
+                <parameter>attrib_list</parameter> parameter
+            </title>
+            <tgroup cols="4" align="left" colsep="1" rowsep="1">
+                <thead>
+                    <row>
+                        <entry><parameter>target</parameter></entry>
+                        <entry>Notes</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry>Attribute</entry>
+                        <entry>Description</entry>
+                        <entry>Valid <parameter>target</parameter>s</entry>
+                        <entry>Default Value</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_NONE</constant></entry>
+                        <entry>Marks the end of the attribute-value list</entry>
+                        <entry>All</entry>
+                        <entry>N/A</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_LEVEL</constant></entry>
+                        <entry>
+                            Specifies the mipmap level used as the
+                            <type>EGLImage</type> source. Must be part of
+                            the complete texture object
+                            <parameter>buffer</parameter>
+                        </entry>
+                        <entry>
+                            <constant>EGL_GL_TEXTURE_2D</constant>,
+                            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant>, or
+                            <constant>EGL_GL_TEXTURE_3D</constant>
+                        </entry>
+                        <entry>0</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_GL_TEXTURE_ZOFFSET</constant></entry>
+                        <entry>
+                            Specifies the depth offset of the image to use
+                            as the <type>EGLImage</type> source. Must be
+                            part of the complete texture object
+                            <parameter>buffer</parameter>
+                        </entry>
+                        <entry><constant>EGL_GL_TEXTURE_3D</constant></entry>
+                        <entry>0</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_IMAGE_PRESERVED</constant></entry>
+                        <entry>Whether to preserve pixel data</entry>
+                        <entry>All</entry>
+                        <entry><constant>EGL_FALSE</constant></entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+        <para>
+            <function>eglCreateImage</function> returns an
+            <type>EGLImage</type> object corresponding to the image data
+            specified by <parameter>display</parameter>,
+            <parameter>context</parameter>, <parameter>target</parameter>,
+            <parameter>buffer</parameter> and
+            <parameter>attrib_list</parameter> which may be referenced by
+            client API operations.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_3D</constant>,
+            <constant>EGL_GL_RENDERBUFFER</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z</constant>, or
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z</constant>,
+            <parameter>display</parameter> must be a valid
+            <type>EGLDisplay</type>, and <parameter>context</parameter> must
+            be a valid OpenGL or OpenGL ES API context on that display.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <parameter>buffer</parameter> must be the name of a nonzero,
+            <constant>GL_TEXTURE_2D</constant> target texture object, cast
+            into the type <type>EGLClientBuffer</type>.
+        </para>
+        <para>
+            If <parameter>target</parameter> is one of the
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant> enumerants,
+            <parameter>buffer</parameter> must be the name of a nonzero,
+            <constant>GL_TEXTURE_CUBE_MAP</constant> (or equivalent in GL
+            extensions) target texture object, cast into the type
+            <type>EGLClientBuffer</type>.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_3D</constant>,
+            <parameter>buffer</parameter> must be the name of a nonzero,
+            <constant>GL_TEXTURE_3D</constant> (or equivalent in GL
+            extensions) target texture object, cast into the type
+            <type>EGLClientBuffer</type>.
+        </para>
+        <para>
+            <parameter>attrib_list</parameter> should specify the mipmap
+            level (<constant>EGL_GL_TEXTURE_LEVEL</constant>) and, where
+            applicable, z-offset
+            (<constant>EGL_GL_TEXTURE_ZOFFSET</constant>) which will be used
+            as the <type>EGLImage</type> source; If not specified, the
+            default values listed in table <xref linkend="tab-imageattr"/>
+            will be used instead. Additional values specified in are
+            ignored.
+        </para>
+        <para>
+            There must exist some levels <emphasis>x</emphasis> and
+            <emphasis>y</emphasis> such that the mipmap level requested lies
+            between <emphasis>x</emphasis> and <emphasis>y</emphasis>
+            (inclusive), the texture would be mipmap complete were
+            <emphasis>x</emphasis> substituted for the base level and
+            <emphasis>y</emphasis> substituted for the max level, and all
+            levels less than <emphasis>x</emphasis> or greater than
+            <emphasis>y</emphasis> are unspecified. For cubemaps a single
+            pair <emphasis>x</emphasis> and <emphasis>y</emphasis> must
+            apply to all faces. For three-dimensional textures, the
+            specified z-offset must be smaller than the depth of the
+            specified mipmap level.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_RENDERBUFFER</constant>,
+            <parameter>buffer</parameter> must be the name of a complete,
+            nonzero, non-multisampled <constant>GL_RENDERBUFFER</constant>
+            (or equivalent in extensions) target object, cast into the type
+            <type>EGLClientBuffer</type>. Values specified in
+            <parameter>attrib_list</parameter> are ignored.
+        </para>
+        <para>
+            If the value of attribute
+            <constant>EGL_IMAGE_PRESERVED</constant> is
+            <constant>EGL_FALSE</constant> (the default), then all pixel
+            data values associated with <parameter>buffer</parameter> will
+            be undefined after <function>eglCreateImage</function> returns.
+        </para>
+        <para>
+            If the value of attribute
+            <constant>EGL_IMAGE_PRESERVED</constant> is
+            <constant>EGL_TRUE</constant>, then all pixel data values
+            associated with <parameter>buffer</parameter> are preserved.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            <function>eglCreateImage</function> returns
+            <constant>EGL_NO_IMAGE</constant> on failure. The contents of
+            <parameter>buffer</parameter> will be unaffected.
+        </para>
+        <para>
+            If <parameter>display</parameter> is not the handle of a valid
+            <type>EGLDisplay</type> object, the error
+            <constant>EGL_BAD_DISPLAY</constant> is generated.
+        </para>
+        <para>
+            If <parameter>context</parameter> is neither the handle of a
+            valid <type>EGLContext</type> object on
+            <parameter>display</parameter> nor
+            <constant>EGL_NO_CONTEXT</constant>, the error
+            <constant>EGL_BAD_CONTEXT</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is not one of the values in
+            table <xref linkend="tab-imagetarget"/>, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant>,
+            <constant>EGL_GL_RENDERBUFFER</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant>, and
+            <parameter>display</parameter> is not a valid
+            <type>EGLDisplay</type>, the error
+            <constant>EGL_BAD_DISPLAY</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant>,
+            <constant>EGL_GL_RENDERBUFFER</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant>, and
+            <parameter>context</parameter> is not a valid
+            <type>EGLContext</type>, the error
+            <constant>EGL_BAD_CONTEXT</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant>,
+            <constant>EGL_GL_RENDERBUFFER</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant>, and
+            <parameter>context</parameter> is not a valid GL context, or
+            does not match the <parameter>display</parameter>, the error
+            <constant>EGL_BAD_MATCH</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant> and
+            <parameter>buffer</parameter> is not the name of a texture
+            object of type <parameter>target</parameter>, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_RENDERBUFFER</constant> and
+            <parameter>buffer</parameter> is not the name of a renderbuffer
+            object, or if <parameter>buffer</parameter> is the name of a
+            multisampled renderbuffer object, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+        <para>
+            If <constant>EGL_GL_TEXTURE_LEVEL</constant> is nonzero,
+            <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant>, and
+            <parameter>buffer</parameter> is not the name of a complete GL
+            texture object, the error <constant>EGL_BAD_PARAMETER</constant>
+            is generated.
+        </para>
+        <para>
+            If <constant>EGL_GL_TEXTURE_LEVEL</constant> is 0,
+            <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant>,
+            <parameter>buffer</parameter> is the name of an incomplete GL
+            texture object, and any mipmap levels other than mipmap level 0
+            are specified, the error <constant>EGL_BAD_PARAMETER</constant>
+            is generated.
+        </para>
+        <para>
+            If <constant>EGL_GL_TEXTURE_LEVEL</constant> is 0,
+            <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant>,
+            <parameter>buffer</parameter> is not the name of a complete GL
+            texture object, and mipmap level 0 is not specified, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+        <para>
+            If <constant>EGL_GL_TEXTURE_LEVEL</constant> is 0,
+            <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant>,
+            <parameter>buffer</parameter> is not the name of a complete GL
+            texture object, and one or more faces do not have mipmap level 0
+            specified, the error <constant>EGL_BAD_PARAMETER</constant> is
+            generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant>,
+            <constant>EGL_GL_RENDERBUFFER</constant> or
+            <constant>EGL_GL_TEXTURE_3D</constant> and
+            <parameter>buffer</parameter> refers to the default GL texture
+            object (0) for the corresponding GL target, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_2D</constant>,
+            <constant>EGL_GL_TEXTURE_CUBE_MAP_*</constant>, or
+            <constant>EGL_GL_TEXTURE_3D</constant>, and the value specified
+            in <parameter>attrib_list</parameter> for
+            <constant>EGL_GL_TEXTURE_LEVEL</constant> is not a valid mipmap
+            level for the specified GL texture object
+            <parameter>buffer</parameter>, the error
+            <constant>EGL_BAD_MATCH</constant> is generated.
+        </para>
+        <para>
+            If <parameter>target</parameter> is
+            <constant>EGL_GL_TEXTURE_3D</constant>, and the value specified
+            in <parameter>attrib_list</parameter> for
+            <constant>EGL_GL_TEXTURE_ZOFFSET</constant> exceeds the depth of
+            the specified mipmap level-of-detail in
+            <parameter>buffer</parameter>, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+        <para>
+            If an attribute specified in <parameter>attrib_list</parameter>
+            is not one of the attributes shown in table <xref
+            linkend="tab-imageattr"/>, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+        <para>
+            If an attribute specified in <parameter>attrib_list</parameter>
+            is not a valid attribute for <parameter>target</parameter>, as
+            shown in table <xref linkend="tab-imageattr"/>, the error
+            <constant>EGL_BAD_MATCH</constant> is generated.
+        </para>
+        <para>
+            If the resource specified by <parameter>display</parameter>,
+            <parameter>context</parameter>, <parameter>target</parameter>,
+            <parameter>buffer</parameter> and
+            <parameter>attrib_list</parameter> has an off-screen buffer
+            bound to it (e.g., by a previous call to
+            <function>eglBindTexImage</function>), the error
+            <constant>EGL_BAD_ACCESS</constant> is generated.
+        </para>
+        <para>
+            If the resource specified by <parameter>display</parameter>,
+            <parameter>context</parameter>, <parameter>target</parameter>,
+            <parameter>buffer</parameter> and
+            <parameter>attrib_list</parameter> is bound to an off-screen
+            buffer (e.g., by a previous call to
+            <function>eglCreatePbufferFromClientBuffer</function>), the
+            error <constant>EGL_BAD_ACCESS</constant> is generated.
+        </para>
+        <para>
+            If the resource specified by <parameter>display</parameter>,
+            <parameter>context</parameter>, <parameter>target</parameter>,
+            <parameter>buffer</parameter> and
+            <parameter>attrib_list</parameter> is itself an
+            <type>EGLImage</type> sibling, the error
+            <constant>EGL_BAD_ACCESS</constant> is generated.
+        </para>
+        <para>
+            If insufficient memory is available to complete the specified
+            operation, the error <constant>EGL_BAD_ALLOC</constant> is
+            generated.
+        </para>
+        <para>
+            If the value specified in <parameter>attrib_list</parameter> for
+            <constant>EGL_IMAGE_PRESERVED</constant> is
+            <constant>EGL_TRUE</constant>, and an <type>EGLImage</type>
+            handle cannot be created from the specified resource such that
+            the pixel data values in <parameter>buffer</parameter> are
+            preserved, the error <constant>EGL_BAD_ACCESS</constant> is
+            generated.
+        </para>
+        <para>
+            Note that the success or failure of
+            <function>eglCreateImage</function> should not affect the
+            ability to use <parameter>buffer</parameter> in its original API
+            context (or context share group) (although the pixel data values
+            will be undefined if the command succeeds and the value of
+            <constant>EGL_IMAGE_PRESERVED</constant> is not
+            <constant>EGL_TRUE</constant>).
+        </para>
+    </refsect1>
+    <refsect1 xml:id="lifetime"><title>Lifetime and Usage of <type>EGLImage</type>s</title>
+        <para>
+            Once an <type>EGLImage</type> is created from an
+            <type>EGLImage</type> source, the memory associated with the
+            <type>EGLImage</type> source will remain allocated (and all
+            <type>EGLImage</type> siblings in all client API contexts will
+            be useable) as long as either of the following conditions is
+            true:
+        </para>
+        <para>
+            <itemizedlist>
+            <listitem>
+                <para>
+                     Any <type>EGLImage</type> siblings exist in any client
+                     API context
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    The <type>EGLImage</type> object exists inside EGL
+                </para>
+            </listitem>
+            </itemizedlist>
+        </para>
+        <para>
+            The semantics for specifying, deleting and using
+            <type>EGLImage</type> siblings are client API-specific, and are
+            described in the appropriate API specifications.
+        </para>
+        <para>
+            If an application specifies an <type>EGLImage</type> sibling as
+            the destination for rendering and/or pixel download operations
+            (e.g., as an OpenGL or OpenGL ES framebuffer object,
+            <function>glTexSubImage2D</function>, etc.), the modified image
+            results will be observed by all <type>EGLImage</type> siblings
+            in all client API contexts. If multiple client API contexts
+            access <type>EGLImage</type> sibling resources simultaneously,
+            with one or more context modifying the image data, rendering
+            results in all contexts accessing <type>EGLImage</type> siblings
+            are undefined.
+        </para>
+        <para>
+            Respecification and/or deletion of any <type>EGLImage</type>
+            sibling (i.e., both <type>EGLImage</type> source and
+            <type>EGLImage</type> target resources) inside a client API
+            context (by issuing a subsequent call to commands such as
+            <function>glTexImage*</function> or
+            <function>glDeleteTextures</function>, with the
+            <type>EGLImage</type> sibling resource as the target of the
+            operation) affects only that client API context and other
+            contexts within its share group. For an OpenGL or OpenGL ES
+            context, respecification always results in
+            <firstterm>orphaning</firstterm> of the <type>EGLImage</type>,
+            and may also include allocation of additional memory for the
+            respecified resource and/or copying of the <type>EGLImage</type>
+            pixel data.
+        </para>
+        <para>
+            Note: Behavior of other types of client APIs generally follows
+            the OpenGL and OpenGL ES behavior described here, although this
+            is not mandated yet.
+        </para>
+        <para>
+            Operations inside EGL or any client API context which may affect
+            the lifetime of an <type>EGLImage</type> (or the memory
+            allocated for the <type>EGLImage</type>), such as respecifying
+            and/or deleting an <type>EGLImage</type> sibling inside a client
+            API context, must be atomic.
+        </para>
+        <para>
+            Applications may create client API resources from an
+            <type>EGLImage</type> using client API extensions outside the
+            scope of this document (such as
+            <constant>GL_OES_EGL_image</constant>, which creates OpenGL ES
+            texture and renderbuffer objects). If the <type>EGLImage</type>
+            used to create the client resource was created with the
+            <constant>EGL_IMAGE_PRESERVED</constant> attribute set to
+            <constant>EGL_TRUE</constant>, then the pixel data values
+            associated with the image will be preserved after creating the
+            client resource; otherwise, the pixel data values will be
+            undefined. If the <type>EGLImage</type> was created with the
+            <constant>EGL_IMAGE_PRESERVED</constant> attribute set to
+            <constant>EGL_TRUE</constant>, and EGL is unable to create the
+            client resource without modifying the pixel values, then
+            creation will fail and the pixel data values will be preserved.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglCreateImage</function> is available only if the EGL
+            version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>eglBindTexImage</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglCreatePbufferFromClientBuffer</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglDestroyImage</refentrytitle></citerefentry>,
+            <function>glDeleteTextures</function>,
+            <function>glTexImage*</function>,
+            <function>glTexSubImage2D</function>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/eglCreateImage.xml
+++ b/sdk/docs/man/eglCreateImage.xml
@@ -58,7 +58,7 @@
             <varlistentry>
                 <term><parameter>attrib_list</parameter></term>
                 <listitem><para>
-                    Specifies attributes used to select sub-sectins of the
+                    Specifies attributes used to select sub-sections of the
                     resource to be used as the image source.
                 </para></listitem>
             </varlistentry>

--- a/sdk/docs/man/eglCreateImage.xml
+++ b/sdk/docs/man/eglCreateImage.xml
@@ -37,7 +37,7 @@
                 </para></listitem>
             </varlistentry>
             <varlistentry>
-                <term><parameter>sync</parameter></term>
+                <term><parameter>context</parameter></term>
                 <listitem><para>
                     Specifies the client API context for which the image is
                     created.

--- a/sdk/docs/man/eglCreatePbufferFromClientBuffer.xml
+++ b/sdk/docs/man/eglCreatePbufferFromClientBuffer.xml
@@ -298,6 +298,11 @@
             section above.
         </para>
         <para>
+            <constant>EGL_BAD_ACCESS</constant> is generated if the buffers
+            contained in <parameter>buffer</parameter> consist of any
+            <type>EGLImage</type> siblings.
+        </para>
+        <para>
             <constant>EGL_BAD_ALLOC</constant> is generated if there are not
             enough resources to allocate the new surface.
         </para>
@@ -322,8 +327,9 @@
         </para>
         <para>
             <constant>EGL_BAD_MATCH</constant> is generated if
-            <parameter>config</parameter> does not support rendering to pixel buffers
-            (the <constant>EGL_SURFACE_TYPE</constant> attribute does not contain
+            <parameter>config</parameter> does not support rendering to
+            pixel buffers (the <constant>EGL_SURFACE_TYPE</constant>
+            attribute does not contain
             <constant>EGL_PBUFFER_BIT</constant>).
         </para>
         <para>

--- a/sdk/docs/man/eglCreatePixmapSurface.xml
+++ b/sdk/docs/man/eglCreatePixmapSurface.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreatePixmapSurface">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -12,7 +12,7 @@
     <refnamediv>
         <refname>eglCreatePixmapSurface</refname>
         <refpurpose>
-            create a new <acronym>EGL</acronym> pixmap surface
+            create a new <acronym>EGL</acronym> offscreen surface
         </refpurpose>
     </refnamediv>
     <refsynopsisdiv>
@@ -56,157 +56,26 @@
     </refsect1>
     <refsect1 xml:id="description"><title>Description</title>
         <para>
-            <function>eglCreatePixmapSurface</function> creates an
-            off-screen <acronym>EGL</acronym> pixmap surface and returns
-            its handle. If <function>eglCreatePixmapSurface</function>
-            fails to create a pixmap surface,
-            <constant>EGL_NO_SURFACE</constant> is returned.
-        </para>
-        <para>
-            Surface attributes are specified as a list of
-            attribute-value pairs, terminated with
-            <constant>EGL_NONE</constant>. Accepted attributes
-            are:
-        </para>
-        <variablelist>
-            <varlistentry>
-                <term><constant>EGL_VG_ALPHA_FORMAT</constant></term>
-                <listitem>
-                <para>
-                    Specifies how alpha values are interpreted by OpenVG
-                    when rendering to the surface. If its value is
-                    <constant>EGL_VG_ALPHA_FORMAT_NONPRE</constant>,
-                    then alpha values are not premultipled. If its value
-                    is <constant>EGL_VG_ALPHA_FORMAT_PRE</constant>,
-                    then alpha values are premultiplied. The default
-                    value of <constant>EGL_VG_ALPHA_FORMAT</constant> is
-                    <constant>EGL_VG_ALPHA_FORMAT_NONPRE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_VG_COLORSPACE</constant></term>
-                <listitem>
-                <para>
-                    Specifies the color space used by OpenVG when
-                    rendering to the surface. If its value is
-                    <constant>EGL_VG_COLORSPACE_sRGB</constant>, then a
-                    non-linear, perceptually uniform color space is
-                    assumed, with a corresponding
-                    <type>VGImageFormat</type> of form
-                    <constant>VG_s*</constant>. If its value is
-                    <constant>EGL_VG_COLORSPACE_LINEAR</constant>, then
-                    a linear color space is assumed, with a
-                    corresponding <type>VGImageFormat</type> of form
-                    <constant>VG_l*</constant>. The default value of
-                    <constant>EGL_VG_COLORSPACE</constant> is
-                    <constant>EGL_VG_COLORSPACE_sRGB</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-        </variablelist>
-        <para>
-            Any EGL rendering context that was created with respect to
-            <parameter>config</parameter> can be used to render into the
-            surface. Use
-            <citerefentry><refentrytitle>eglMakeCurrent</refentrytitle></citerefentry>
-            to attach an EGL rendering context to the surface.
-        </para>
-        <para>
-            Use
-            <citerefentry><refentrytitle>eglQuerySurface</refentrytitle></citerefentry>
-            to retrieve the ID of <parameter>config</parameter>.
-        </para>
-        <para>
-            Use <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>
-            to destroy the surface.
-        </para>
-    </refsect1>
-    <refsect1 xml:id="notes"><title>Notes</title>
-        <para>
-            The <constant>EGL_MATCH_NATIVE_PIXMAP</constant> attribute
+            <function>eglCreatePixmapSurface</function> creates an on-screen
+            EGL window surface and returns a handle to it. The behavior of
+            <function>eglCreatePixmapSurface</function> is identical to that
             of
-            <citerefentry><refentrytitle>eglChooseConfig</refentrytitle></citerefentry>
-            can be used to select a frame buffer configuration matching
-            a specified native pixmap.
-        </para>
-        <para>
-            Attributes
-            <constant>EGL_VG_ALPHA_FORMAT</constant> and
-            <constant>EGL_VG_COLORSPACE</constant>, and the
-            corresponding attribute values, are supported only if the
-            EGL version is 1.2 or greater.
-        </para>
-        <!-- Might want to mention aliasing of EGL_VG_* -> EGL_* that occurred in EGL 1.3 -->
-        <para>
-            The <constant>EGL_VG_ALPHA_FORMAT</constant> and
-            <constant>EGL_VG_COLORSPACE</constant> attributes are used
-            only by OpenVG. EGL itself, and other client APIs such as
-            OpenGL and OpenGL ES , do not distinguish multiple
-            colorspace models. Refer to section 11.2 of the OpenVG 1.0
-            specification for more information. The native window
-            system's use and interpretation of alpha values is outside
-            the scope of EGL, although the preferred behavior is for the
-            window system to ignore the value of
-            <constant>EGL_VG_ALPHA_FORMAT</constant>.
+            <citerefentry><refentrytitle>eglCreatePlatformPixmapSurface</refentrytitle></citerefentry>
+            except that the set of platforms to which
+            <parameter>display</parameter> is permitted to belong, as well
+            as the actual type of <parameter>native_pixmap</parameter>, are
+            implementation specific.
         </para>
     </refsect1>
     <refsect1 xml:id="errors"><title>Errors</title>
         <para>
-            <constant>EGL_NO_SURFACE</constant> is returned if creation of
-            the context fails.
-        </para>
-        <para>
-            <constant>EGL_BAD_DISPLAY</constant> is generated if
-            <parameter>display</parameter> is not an EGL display connection.
-        </para>
-        <para>
-            <constant>EGL_NOT_INITIALIZED</constant> is generated if
-            <parameter>display</parameter> has not been initialized.
-        </para>
-        <para>
-            <constant>EGL_BAD_CONFIG</constant> is generated if
-            <parameter>config</parameter> is not an EGL config.
-        </para>
-        <para>
-            <constant>EGL_BAD_NATIVE_PIXMAP</constant> may be generated if
-            <parameter>native_pixmap</parameter> is not a valid native pixmap.
-        </para>
-        <para>
-            <constant>EGL_BAD_ATTRIBUTE</constant> is generated if
-            <parameter>attrib_list</parameter> contains an invalid pixmap attribute
-            or if an attribute value is not recognized or out of range.
-        </para>
-        <para>
-            <constant>EGL_BAD_ALLOC</constant> is generated if there are not
-            enough resources to allocate the new surface.
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if the attributes of
-            <parameter>native_pixmap</parameter> do not correspond to
-            <parameter>config</parameter> or if
-            <parameter>config</parameter> does not support rendering to pixmaps
-            (the <constant>EGL_SURFACE_TYPE</constant> attribute does not contain
-            <constant>EGL_PIXMAP_BIT</constant>).
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if
-            <parameter>config</parameter> does not support the specified
-            OpenVG alpha format attribute (the value of
-            <constant>EGL_VG_ALPHA_FORMAT</constant> is
-            <constant>EGL_VG_ALPHA_FORMAT_PRE</constant> and the
-            <constant>EGL_VG_ALPHA_FORMAT_PRE_BIT</constant> is not set
-            in the <constant>EGL_SURFACE_TYPE</constant> attribute of
-            <parameter>config</parameter>) or colorspace attribute (the
-            value of <constant>EGL_VG_COLORSPACE</constant> is
-            <constant>EGL_VG_COLORSPACE_LINEAR</constant> and the
-            <constant>EGL_VG_COLORSPACE_LINEAR_IT</constant> is not set
-            in the <constant>EGL_SURFACE_TYPE</constant> attribute of
-            <parameter>config</parameter>).
+            See errors for
+            <citerefentry><refentrytitle>eglCreatePlatformPixmapSurface</refentrytitle></citerefentry>.
         </para>
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>
         <para>
+            <citerefentry><refentrytitle>eglCreatePlatformPixmapSurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglChooseConfig</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglGetConfigs</refentrytitle></citerefentry>,

--- a/sdk/docs/man/eglCreatePlatformPixmapSurface.xml
+++ b/sdk/docs/man/eglCreatePlatformPixmapSurface.xml
@@ -1,27 +1,28 @@
-<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreatePbufferSurface">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreatePlatformPixmapSurface">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
     <refmeta>
-        <refentrytitle>eglCreatePbufferSurface</refentrytitle>
+        <refentrytitle>eglCreatePlatformPixmapSurface</refentrytitle>
         <manvolnum>3G</manvolnum>
     </refmeta>
     <refnamediv>
-        <refname>eglCreatePbufferSurface</refname>
+        <refname>eglCreatePlatformPixmapSurface</refname>
         <refpurpose>
-            create a new <acronym>EGL</acronym> pixel buffer surface
+            create a new <acronym>EGL</acronym> offscreen surface
         </refpurpose>
     </refnamediv>
     <refsynopsisdiv>
         <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>EGLSurface <function>eglCreatePbufferSurface</function></funcdef>
+                <funcdef>EGLSurface <function>eglCreatePlatformPixmapSurface</function></funcdef>
                 <paramdef>EGLDisplay <parameter>display</parameter></paramdef>
                 <paramdef>EGLConfig <parameter>config</parameter></paramdef>
+                <paramdef>void * <parameter>native_pixmap</parameter></paramdef>
                 <paramdef>EGLint const * <parameter>attrib_list</parameter></paramdef>
             </funcprototype>
         </funcsynopsis>
@@ -36,13 +37,17 @@
                 <term><parameter>config</parameter></term>
                 <listitem><para>
                     Specifies the EGL frame buffer configuration that defines the
-                    frame buffer resource available to the surface.
-                </para></listitem>
+                    frame buffer resource available to the surface.</para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>native_pixmap</parameter></term>
+                <listitem><para>Specifies the native pixmap.</para></listitem>
             </varlistentry>
             <varlistentry>
                 <term><parameter>attrib_list</parameter></term>
                 <listitem><para>
-                    Specifies pixel buffer surface attributes.
+                    Specifies pixmap surface attributes.
                     May be <constant>NULL</constant> or empty
                     (first attribute is <constant>EGL_NONE</constant>).
                 </para></listitem>
@@ -51,11 +56,23 @@
     </refsect1>
     <refsect1 xml:id="description"><title>Description</title>
         <para>
-            <function>eglCreatePbufferSurface</function> creates an
-            off-screen pixel buffer surface and returns its handle. If
-            <function>eglCreatePbufferSurface</function> fails to create
-            a pixel buffer surface, <constant>EGL_NO_SURFACE</constant>
-            is returned.
+            <function>eglCreatePlatformPixmapSurface</function> creates an
+            off-screen <acronym>EGL</acronym> pixmap surface and returns
+            a handle to it.
+        </para>
+        <para>
+            If <function>eglCreatePlatformPixmapSurface</function> fails to
+            create a pixmap surface, <constant>EGL_NO_SURFACE</constant> is
+            returned.
+        </para>
+        <para>
+            <parameter>native_pixmap</parameter> must belong to the same
+            platform as <parameter>display</parameter>, and EGL considers
+            the returned <type>EGLSurface</type> as belonging to that same
+            platform. The EGL extension that defines the platform to which
+            <parameter>display</parameter> belongs also defines the
+            requirements for the <parameter>native_pixmap</parameter>
+            parameter.
         </para>
         <para>
             Surface attributes are specified as a list of
@@ -89,70 +106,6 @@
                     distinguish multiple colorspace models. Refer to the
                     ``sRGB Conversion'' sections of the OpenGL 4.6 and
                     OpenGL ES 3.2 Specifications for more information.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_HEIGHT</constant></term>
-                <listitem>
-                <para>
-                    Specifies the required height of the pixel buffer
-                    surface. The default value is
-                    <constant>0</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_LARGEST_PBUFFER</constant></term>
-                <listitem>
-                <para>
-                    Requests the largest available pixel buffer surface
-                    when the allocation would otherwise fail. Use
-                    <citerefentry><refentrytitle>eglQuerySurface</refentrytitle></citerefentry>
-                    to retrieve the dimensions of the allocated pixel
-                    buffer. The default value is
-                    <constant>EGL_FALSE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_MIPMAP_TEXTURE</constant></term>
-                <listitem>
-                <para>
-                    Specifies whether storage for mipmaps should be
-                    allocated. Space for mipmaps will be set aside if
-                    the attribute value is <constant>EGL_TRUE</constant>
-                    and <constant>EGL_TEXTURE_FORMAT</constant> is not
-                    <constant>EGL_NO_TEXTURE</constant>. The default
-                    value is <constant>EGL_FALSE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_TEXTURE_FORMAT</constant></term>
-                <listitem>
-                <para>
-                    Specifies the format of the texture that will be
-                    created when a pbuffer is bound to a texture map.
-                    Possible values are
-                    <constant>EGL_NO_TEXTURE</constant>,
-                    <constant>EGL_TEXTURE_RGB</constant>, and
-                    <constant>EGL_TEXTURE_RGBA</constant>. The default
-                    value is <constant>EGL_NO_TEXTURE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_TEXTURE_TARGET</constant></term>
-                <listitem>
-                <para>
-                    Specifies the target for the texture that will be
-                    created when the pbuffer is created with a texture
-                    format of <constant>EGL_TEXTURE_RGB</constant> or
-                    <constant>EGL_TEXTURE_RGBA</constant>. Possible
-                    values are <constant>EGL_NO_TEXTURE</constant>, or
-                    <constant>EGL_TEXTURE_2D</constant>. The default
-                    value is <constant>EGL_NO_TEXTURE</constant>.
                 </para>
                 </listitem>
             </varlistentry>
@@ -191,16 +144,6 @@
                 </para>
                 </listitem>
             </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_WIDTH</constant></term>
-                <listitem>
-                <para>
-                    Specifies the required width of the pixel buffer
-                    surface. The default value is
-                    <constant>0</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
         </variablelist>
         <para>
             Any EGL rendering context that was created with respect to
@@ -212,8 +155,7 @@
         <para>
             Use
             <citerefentry><refentrytitle>eglQuerySurface</refentrytitle></citerefentry>
-            to retrieve the dimensions of the allocated pixel buffer
-            surface or the ID of <parameter>config</parameter>.
+            to retrieve the ID of <parameter>config</parameter>.
         </para>
         <para>
             Use <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>
@@ -222,50 +164,43 @@
     </refsect1>
     <refsect1 xml:id="notes"><title>Notes</title>
         <para>
-            Attribute <constant>EGL_GL_COLORSPACE</constant>, and the
-            <constant>EGL_OPENGL_ES3_BIT</constant> bit value for attribute
-            <constant>EGL_RENDERABLE_TYPE</constant>, are supported only if
-            the EGL version is 1.5 or greater.
+            The <constant>EGL_MATCH_NATIVE_PIXMAP</constant> attribute
+            of
+            <citerefentry><refentrytitle>eglChooseConfig</refentrytitle></citerefentry>
+            can be used to select a frame buffer configuration matching
+            a specified native pixmap.
+        </para>
+        <para>
+            Attribute <constant>EGL_GL_COLORSPACE</constant> is supported
+            only if the EGL version is 1.5 or greater.
         </para>
         <para>
             Attributes
-            <constant>EGL_RENDERABLE_TYPE</constant>,
-            <constant>EGL_VG_ALPHA_FORMAT</constant>, and
+            <constant>EGL_VG_ALPHA_FORMAT</constant> and
             <constant>EGL_VG_COLORSPACE</constant>, and the
             corresponding attribute values, are supported only if the
             EGL version is 1.2 or greater.
         </para>
+        <!-- Might want to mention aliasing of EGL_VG_* -> EGL_* that occurred in EGL 1.3 -->
         <para>
-            If the value of <parameter>config</parameter> attribute
-            <constant>EGL_TEXTURE_FORMAT</constant> is not
-            <constant>EGL_NO_TEXTURE</constant>, then the pbuffer width
-            and height specify the size of the level zero texture image
-        </para>
-        <para>
-            If <constant>EGL_LARGEST_PBUFFER</constant> is specified and
-            if the pbuffer will be used as a texture (i.e. the value of
-            <constant>EGL_TEXTURE_TARGET</constant> is
-            <constant>EGL_TEXTURE_2D</constant>, and the value of
-            <constant>EGL_TEXTURE FORMAT</constant> is
-            <constant>EGL_TEXTURE_RGB</constant> or
-            <constant>EGL_TEXTURE_RGBA</constant>), then the aspect
-            ratio will be preserved and the new width and height will be
-            valid sizes for the texture target (e.g. if the underlying
-            OpenGL ES implementation does not support non-power-of-two
-            textures, both the width and height will be a power of 2).
-        </para>
-        <para>
-            The contents of the depth and stencil buffers may not be
-            preserved when rendering a texture to the pbuffer and
-            switching which image of the texture is rendered to (e.g.,
-            switching from rendering one mipmap level to rendering
-            another).
+            The <constant>EGL_VG_ALPHA_FORMAT</constant> and
+            <constant>EGL_VG_COLORSPACE</constant> attributes are used only
+            by OpenVG and EGL itself. Refer to section 11.2 of the OpenVG
+            1.0 specification for more information. The platform's use and
+            interpretation of alpha values is outside the scope of EGL.
+            However, the preferred behavior is for the window system to
+            ignore the value of <constant>EGL_VG_ALPHA_FORMAT</constant>.
         </para>
     </refsect1>
     <refsect1 xml:id="errors"><title>Errors</title>
         <para>
+            If <parameter>display</parameter> and
+            <parameter>native_pixmap</parameter> do not belong to the same
+            platform, then undefined behavior occurs.
+        </para>
+        <para>
             <constant>EGL_NO_SURFACE</constant> is returned if creation of
-            the context fails.
+            the surface fails.
         </para>
         <para>
             <constant>EGL_BAD_DISPLAY</constant> is generated if
@@ -277,58 +212,34 @@
         </para>
         <para>
             <constant>EGL_BAD_CONFIG</constant> is generated if
-            <parameter>config</parameter> is not an EGL frame buffer configuration.
+            <parameter>config</parameter> is not an EGL config.
+        </para>
+        <para>
+            <constant>EGL_BAD_NATIVE_PIXMAP</constant> may be generated if
+            <parameter>native_pixmap</parameter> is not a valid native pixmap.
         </para>
         <para>
             <constant>EGL_BAD_ATTRIBUTE</constant> is generated if
-            <parameter>attrib_list</parameter> contains an invalid pixel
-            buffer attribute or if an attribute value is not recognized
-            or out of range.
+            <parameter>attrib_list</parameter> contains an invalid pixmap attribute
+            or if an attribute value is not recognized or out of range.
         </para>
         <para>
-            <constant>EGL_BAD_ATTRIBUTE</constant> is generated if
-            <parameter>attrib_list</parameter> contains any of the
-            attributes <constant>EGL_MIPMAP_TEXTURE</constant>,
-            <constant>EGL_TEXTURE_FORMAT</constant>, or
-            <constant>EGL_TEXTURE_TARGET</constant>, and
-            <parameter>config</parameter> does not support OpenGL ES
-            rendering (e.g. the EGL version is 1.2 or later, and the
-            <constant>EGL_RENDERABLE_TYPE</constant> attribute of
-            <parameter>config</parameter> does not include at least one
-            of <constant>EGL_OPENGL_ES_BIT</constant>,
-            <constant>EGL_OPENGL_ES2_BIT</constant>), or
-            <constant>EGL_OPENGL_ES3_BIT</constant>),
+            <constant>EGL_BAD_ALLOC</constant> is generated if there is
+            already an <type>EGLSurface</type> associated with
+            <parameter>native_pixmap</parameter> (as a result of a previous
+            <function>eglCreatePlatformPixmapSurface</function> call).
         </para>
         <para>
-            <constant>EGL_BAD_ALLOC</constant> is generated if there are not
-            enough resources to allocate the new surface.
+            <constant>EGL_BAD_ALLOC</constant> is generated if the
+            implementation cannot allocate resources for the new EGL window.
         </para>
         <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if
-            <parameter>config</parameter> does not support rendering to pixel buffers
+            <constant>EGL_BAD_MATCH</constant> is generated if the attributes of
+            <parameter>native_pixmap</parameter> do not correspond to
+            <parameter>config</parameter> or if
+            <parameter>config</parameter> does not support rendering to pixmaps
             (the <constant>EGL_SURFACE_TYPE</constant> attribute does not contain
-            <constant>EGL_PBUFFER_BIT</constant>).
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if the
-            <constant>EGL_TEXTURE_FORMAT</constant> attribute is not
-            <constant>EGL_NO_TEXTURE</constant>, and
-            <constant>EGL_WIDTH</constant> and/or
-            <constant>EGL_HEIGHT</constant> specify an invalid size
-            (e.g., the texture size is not a power of 2, and the
-            underlying OpenGL ES implementation does not support
-            non-power-of-two textures).
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if
-            the <constant>EGL_TEXTURE_FORMAT</constant> attribute is
-            <constant>EGL_NO_TEXTURE</constant>, and
-            <constant>EGL_TEXTURE_TARGET</constant> is something other
-            than <constant>EGL_NO_TEXTURE</constant>; or,
-            <constant>EGL_TEXTURE_FORMAT</constant> is something other
-            than <constant>EGL_NO_TEXTURE</constant>, and
-            <constant>EGL_TEXTURE_TARGET</constant> is
-            <constant>EGL_NO_TEXTURE</constant>.
+            <constant>EGL_PIXMAP_BIT</constant>).
         </para>
         <para>
             <constant>EGL_BAD_MATCH</constant> is generated if

--- a/sdk/docs/man/eglCreatePlatformWindowSurface.xml
+++ b/sdk/docs/man/eglCreatePlatformWindowSurface.xml
@@ -1,28 +1,29 @@
-<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreatePbufferSurface">
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreatePlatformWindowSurface">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
     <refmeta>
-        <refentrytitle>eglCreatePbufferSurface</refentrytitle>
+        <refentrytitle>eglCreatePlatformWindowSurface</refentrytitle>
         <manvolnum>3G</manvolnum>
     </refmeta>
     <refnamediv>
-        <refname>eglCreatePbufferSurface</refname>
+        <refname>eglCreatePlatformWindowSurface</refname>
         <refpurpose>
-            create a new <acronym>EGL</acronym> pixel buffer surface
+            create a new <acronym>EGL</acronym> on-screen rendering surface
         </refpurpose>
     </refnamediv>
     <refsynopsisdiv>
         <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>EGLSurface <function>eglCreatePbufferSurface</function></funcdef>
+                <funcdef>EGLSurface <function>eglCreatePlatformWindowSurface</function></funcdef>
                 <paramdef>EGLDisplay <parameter>display</parameter></paramdef>
                 <paramdef>EGLConfig <parameter>config</parameter></paramdef>
-                <paramdef>EGLint const * <parameter>attrib_list</parameter></paramdef>
+                <paramdef>void * <parameter>native_window</parameter></paramdef>
+                <paramdef>EGLAttrib const * <parameter>attrib_list</parameter></paramdef>
             </funcprototype>
         </funcsynopsis>
     </refsynopsisdiv>
@@ -34,15 +35,19 @@
             </varlistentry>
             <varlistentry>
                 <term><parameter>config</parameter></term>
-                <listitem><para>
-                    Specifies the EGL frame buffer configuration that defines the
-                    frame buffer resource available to the surface.
-                </para></listitem>
+                <listitem>
+                    <para>Specifies the EGL frame buffer configuration that defines the
+                    frame buffer resource available to the surface.</para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>native_window</parameter></term>
+                <listitem><para>Specifies the native window.</para></listitem>
             </varlistentry>
             <varlistentry>
                 <term><parameter>attrib_list</parameter></term>
                 <listitem><para>
-                    Specifies pixel buffer surface attributes.
+                    Specifies a list of attributes for the window surface.
                     May be <constant>NULL</constant> or empty
                     (first attribute is <constant>EGL_NONE</constant>).
                 </para></listitem>
@@ -51,11 +56,24 @@
     </refsect1>
     <refsect1 xml:id="description"><title>Description</title>
         <para>
-            <function>eglCreatePbufferSurface</function> creates an
-            off-screen pixel buffer surface and returns its handle. If
-            <function>eglCreatePbufferSurface</function> fails to create
-            a pixel buffer surface, <constant>EGL_NO_SURFACE</constant>
-            is returned.
+            <function>eglCreatePlatformWindowSurface</function> creates an
+            on-screen EGL window surface and returns a handle to it. Any EGL
+            context created with a compatible <type>EGLConfig</type> can be
+            used to render into this surface.
+        </para>
+        <para>
+            If <function>eglCreatePlatformWindowSurface</function> fails to
+            create a window surface, <constant>EGL_NO_SURFACE</constant> is
+            returned.
+        </para>
+        <para>
+            <parameter>native_window</parameter> must belong to the same
+            platform as <parameter>display</parameter>, and EGL considers
+            the returned <type>EGLSurface</type> as belonging to that same
+            platform. The EGL extension that defines the platform to which
+            <parameter>display</parameter> belongs also defines the
+            requirements for the <parameter>native_window</parameter>
+            parameter.
         </para>
         <para>
             Surface attributes are specified as a list of
@@ -93,66 +111,24 @@
                 </listitem>
             </varlistentry>
             <varlistentry>
-                <term><constant>EGL_HEIGHT</constant></term>
+                <term><constant>EGL_RENDER_BUFFER</constant></term>
                 <listitem>
                 <para>
-                    Specifies the required height of the pixel buffer
-                    surface. The default value is
-                    <constant>0</constant>.
+                    Specifies which buffer should be used for client API
+                    rendering to the window. If its value is
+                    <constant>EGL_SINGLE_BUFFER</constant>, then client
+                    APIs should render directly into the visible window.
+                    If its value is
+                    <constant>EGL_BACK_BUFFER</constant>, then client
+                    APIs should render into the back buffer. The default
+                    value of <constant>EGL_RENDER_BUFFER</constant> is
+                    <constant>EGL_BACK_BUFFER</constant>.
                 </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_LARGEST_PBUFFER</constant></term>
-                <listitem>
                 <para>
-                    Requests the largest available pixel buffer surface
-                    when the allocation would otherwise fail. Use
-                    <citerefentry><refentrytitle>eglQuerySurface</refentrytitle></citerefentry>
-                    to retrieve the dimensions of the allocated pixel
-                    buffer. The default value is
-                    <constant>EGL_FALSE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_MIPMAP_TEXTURE</constant></term>
-                <listitem>
-                <para>
-                    Specifies whether storage for mipmaps should be
-                    allocated. Space for mipmaps will be set aside if
-                    the attribute value is <constant>EGL_TRUE</constant>
-                    and <constant>EGL_TEXTURE_FORMAT</constant> is not
-                    <constant>EGL_NO_TEXTURE</constant>. The default
-                    value is <constant>EGL_FALSE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_TEXTURE_FORMAT</constant></term>
-                <listitem>
-                <para>
-                    Specifies the format of the texture that will be
-                    created when a pbuffer is bound to a texture map.
-                    Possible values are
-                    <constant>EGL_NO_TEXTURE</constant>,
-                    <constant>EGL_TEXTURE_RGB</constant>, and
-                    <constant>EGL_TEXTURE_RGBA</constant>. The default
-                    value is <constant>EGL_NO_TEXTURE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_TEXTURE_TARGET</constant></term>
-                <listitem>
-                <para>
-                    Specifies the target for the texture that will be
-                    created when the pbuffer is created with a texture
-                    format of <constant>EGL_TEXTURE_RGB</constant> or
-                    <constant>EGL_TEXTURE_RGBA</constant>. Possible
-                    values are <constant>EGL_NO_TEXTURE</constant>, or
-                    <constant>EGL_TEXTURE_2D</constant>. The default
-                    value is <constant>EGL_NO_TEXTURE</constant>.
+                    Client APIs may not be able to respect the requested
+                    rendering buffer. To determine the actual buffer
+                    being rendered to by a context, call
+                    <citerefentry><refentrytitle>eglQueryContext</refentrytitle></citerefentry>.
                 </para>
                 </listitem>
             </varlistentry>
@@ -191,16 +167,6 @@
                 </para>
                 </listitem>
             </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_WIDTH</constant></term>
-                <listitem>
-                <para>
-                    Specifies the required width of the pixel buffer
-                    surface. The default value is
-                    <constant>0</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
         </variablelist>
         <para>
             Any EGL rendering context that was created with respect to
@@ -212,60 +178,47 @@
         <para>
             Use
             <citerefentry><refentrytitle>eglQuerySurface</refentrytitle></citerefentry>
-            to retrieve the dimensions of the allocated pixel buffer
-            surface or the ID of <parameter>config</parameter>.
+            to retrieve the ID of <parameter>config</parameter>.
         </para>
         <para>
-            Use <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>
+            Use
+            <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>
             to destroy the surface.
         </para>
     </refsect1>
     <refsect1 xml:id="notes"><title>Notes</title>
         <para>
-            Attribute <constant>EGL_GL_COLORSPACE</constant>, and the
-            <constant>EGL_OPENGL_ES3_BIT</constant> bit value for attribute
-            <constant>EGL_RENDERABLE_TYPE</constant>, are supported only if
-            the EGL version is 1.5 or greater.
+            Attribute <constant>EGL_GL_COLORSPACE</constant> is supported
+            only if the EGL version is 1.5 or greater.
         </para>
         <para>
-            Attributes
-            <constant>EGL_RENDERABLE_TYPE</constant>,
+            Attributes <constant>EGL_RENDER_BUFFER</constant>,
             <constant>EGL_VG_ALPHA_FORMAT</constant>, and
             <constant>EGL_VG_COLORSPACE</constant>, and the
             corresponding attribute values, are supported only if the
             EGL version is 1.2 or greater.
         </para>
+        <!-- Might want to mention aliasing of EGL_VG_* -> EGL_* that occurred in EGL 1.3 -->
         <para>
-            If the value of <parameter>config</parameter> attribute
-            <constant>EGL_TEXTURE_FORMAT</constant> is not
-            <constant>EGL_NO_TEXTURE</constant>, then the pbuffer width
-            and height specify the size of the level zero texture image
-        </para>
-        <para>
-            If <constant>EGL_LARGEST_PBUFFER</constant> is specified and
-            if the pbuffer will be used as a texture (i.e. the value of
-            <constant>EGL_TEXTURE_TARGET</constant> is
-            <constant>EGL_TEXTURE_2D</constant>, and the value of
-            <constant>EGL_TEXTURE FORMAT</constant> is
-            <constant>EGL_TEXTURE_RGB</constant> or
-            <constant>EGL_TEXTURE_RGBA</constant>), then the aspect
-            ratio will be preserved and the new width and height will be
-            valid sizes for the texture target (e.g. if the underlying
-            OpenGL ES implementation does not support non-power-of-two
-            textures, both the width and height will be a power of 2).
-        </para>
-        <para>
-            The contents of the depth and stencil buffers may not be
-            preserved when rendering a texture to the pbuffer and
-            switching which image of the texture is rendered to (e.g.,
-            switching from rendering one mipmap level to rendering
-            another).
+            The <constant>EGL_VG_ALPHA_FORMAT</constant> and
+            <constant>EGL_VG_COLORSPACE</constant> attributes are used only
+            by OpenVG and EGL itself. Refer to section 11.2 of the OpenVG
+            1.0 specification for more information. The platform's use and
+            interpretation of alpha values is outside the scope of EGL.
+            However, the preferred behavior is for platforms to ignore the
+            value of <constant>EGL_VG_ALPHA_FORMAT</constant> when
+            compositing window surfaces.
         </para>
     </refsect1>
     <refsect1 xml:id="errors"><title>Errors</title>
         <para>
+            If <parameter>display</parameter> and
+            <parameter>native_window</parameter> do not belong to the same
+            platform, then undefined behavior occurs.
+        </para>
+        <para>
             <constant>EGL_NO_SURFACE</constant> is returned if creation of
-            the context fails.
+            the surface fails.
         </para>
         <para>
             <constant>EGL_BAD_DISPLAY</constant> is generated if
@@ -277,58 +230,41 @@
         </para>
         <para>
             <constant>EGL_BAD_CONFIG</constant> is generated if
-            <parameter>config</parameter> is not an EGL frame buffer configuration.
+            <parameter>config</parameter> is not a valid EGL frame buffer
+            configuration.
+        </para>
+        <para>
+            <constant>EGL_BAD_NATIVE_WINDOW</constant> may be generated if
+            <parameter>native_window</parameter> is not a valid native
+            window for the same platform as <parameter>display</parameter>.
         </para>
         <para>
             <constant>EGL_BAD_ATTRIBUTE</constant> is generated if
-            <parameter>attrib_list</parameter> contains an invalid pixel
-            buffer attribute or if an attribute value is not recognized
-            or out of range.
+            <parameter>attrib_list</parameter> contains an invalid window attribute
+            or if an attribute value is not recognized or is out of range.
         </para>
         <para>
-            <constant>EGL_BAD_ATTRIBUTE</constant> is generated if
-            <parameter>attrib_list</parameter> contains any of the
-            attributes <constant>EGL_MIPMAP_TEXTURE</constant>,
-            <constant>EGL_TEXTURE_FORMAT</constant>, or
-            <constant>EGL_TEXTURE_TARGET</constant>, and
-            <parameter>config</parameter> does not support OpenGL ES
-            rendering (e.g. the EGL version is 1.2 or later, and the
-            <constant>EGL_RENDERABLE_TYPE</constant> attribute of
-            <parameter>config</parameter> does not include at least one
-            of <constant>EGL_OPENGL_ES_BIT</constant>,
-            <constant>EGL_OPENGL_ES2_BIT</constant>), or
-            <constant>EGL_OPENGL_ES3_BIT</constant>),
+            <constant>EGL_BAD_ALLOC</constant> is generated if there is
+            already an <type>EGLSurface</type> associated with
+            <parameter>native_window</parameter> (as a result of a previous
+            <function>eglCreatePlatformWindowSurface</function> call).
         </para>
         <para>
-            <constant>EGL_BAD_ALLOC</constant> is generated if there are not
-            enough resources to allocate the new surface.
+            <constant>EGL_BAD_ALLOC</constant> is generated if the
+            implementation cannot allocate resources for the new EGL window.
         </para>
         <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if
-            <parameter>config</parameter> does not support rendering to pixel buffers
-            (the <constant>EGL_SURFACE_TYPE</constant> attribute does not contain
-            <constant>EGL_PBUFFER_BIT</constant>).
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if the
-            <constant>EGL_TEXTURE_FORMAT</constant> attribute is not
-            <constant>EGL_NO_TEXTURE</constant>, and
-            <constant>EGL_WIDTH</constant> and/or
-            <constant>EGL_HEIGHT</constant> specify an invalid size
-            (e.g., the texture size is not a power of 2, and the
-            underlying OpenGL ES implementation does not support
-            non-power-of-two textures).
+            <constant>EGL_BAD_MATCH</constant> is generated if the pixel
+            format of <parameter>native_window</parameter> does not
+            correspond to the format, type, and size of the color buffers
+            required by <parameter>config</parameter>.
+            <constant>EGL_BAD_MATCH</constant> is generated if the pixel
         </para>
         <para>
             <constant>EGL_BAD_MATCH</constant> is generated if
-            the <constant>EGL_TEXTURE_FORMAT</constant> attribute is
-            <constant>EGL_NO_TEXTURE</constant>, and
-            <constant>EGL_TEXTURE_TARGET</constant> is something other
-            than <constant>EGL_NO_TEXTURE</constant>; or,
-            <constant>EGL_TEXTURE_FORMAT</constant> is something other
-            than <constant>EGL_NO_TEXTURE</constant>, and
-            <constant>EGL_TEXTURE_TARGET</constant> is
-            <constant>EGL_NO_TEXTURE</constant>.
+            <parameter>config</parameter> does not support rendering to
+            windows (the <constant>EGL_SURFACE_TYPE</constant> attribute
+            does not contain <constant>EGL_WINDOW_BIT</constant>).
         </para>
         <para>
             <constant>EGL_BAD_MATCH</constant> is generated if
@@ -348,6 +284,7 @@
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>
         <para>
+            <citerefentry><refentrytitle>eglCreateWindowSurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglChooseConfig</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglGetConfigs</refentrytitle></citerefentry>,

--- a/sdk/docs/man/eglCreateSync.xml
+++ b/sdk/docs/man/eglCreateSync.xml
@@ -1,0 +1,311 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreateSync">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglCreateSync</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglCreateSync</refname>
+        <refpurpose>
+            create a new <acronym>EGL</acronym> sync object
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+                <funcdef>EGLSync <function>eglCreateSync</function></funcdef>
+                <paramdef>EGLDisplay <parameter>display</parameter></paramdef>
+                <paramdef>EGLEnum <parameter>type</parameter></paramdef>
+                <paramdef>EGLAttrib const * <parameter>attrib_list</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>display</parameter></term>
+                <listitem><para>
+                    Specifies the <acronym>EGL</acronym> display connection.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>type</parameter></term>
+                <listitem><para>
+                    Specifies the type of sync object to create.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>attrib_list</parameter></term>
+                <listitem><para>
+                    Specifies attributes and attribute values for the sync
+                    object being created.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <firstterm>sync objects</firstterm> are provided to enable
+            synchronization of client API operations between threads and/or
+            between API contexts. Sync objects may be tested or waited upon
+            by application threads.
+        </para>
+        <para>
+            Sync objects have a status with two possible states:
+            <firstterm>signaled</firstterm> and
+            <firstterm>unsignaled</firstterm>. Initially, sync objects are
+            unsignaled. EGL may be asked to wait for a sync object to become
+            signaled, or a sync object's status may be queried.
+        </para>
+        <para>
+            Depending on the type of a sync object, its status may be
+            changed either by an external event, or by explicitly signaling
+            and unsignaling the sync.
+        </para>
+        <para>
+            <function>eglCreateSync</function> creates a sync object of the specified
+            <parameter>type</parameter> associated with the specified display
+            <parameter>display</parameter>, and returns a handle to the new object.
+            <parameter>attrib_list</parameter> is an attribute-value list specifying
+            other attributes of the sync object, terminated by an attribute entry
+            <constant>EGL_NONE</constant>. Attributes not specified in the list will be
+            assigned their default values.
+        </para>
+        <para>
+            Once the <firstterm>condition</firstterm> of the sync object is satisfied,
+            the sync is signaled, causing any <function>eglClientWaitSync</function> or
+            <function>eglWaitSync</function> commands blocking on
+            <parameter>sync</parameter> to unblock.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="fencesync"><title>Creating Fence Sync Objects</title>
+        <para>
+            If <parameter>type</parameter> is
+            <constant>EGL_SYNC_FENCE</constant>, a fence sync object is
+            created. In this case <parameter>attrib_list</parameter> must be
+            <constant>NULL</constant> or empty (containing only
+            <constant>EGL_NONE</constant>). Attributes of the fence sync
+            object, and their initial values, are:
+        </para>
+        <variablelist>
+            <varlistentry>
+                <term><constant>EGL_SYNC_TYPE</constant></term>
+                <listitem>
+                    <para>
+                        <constant>EGL_SYNC_FENCE</constant>
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_SYNC_STATUS</constant></term>
+                <listitem>
+                    <para>
+                        <constant>EGL_UNSIGNALED</constant>
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_SYNC_CONDITION</constant></term>
+                <listitem>
+                    <para>
+                        <constant>EGL_SYNC_PRIOR_COMMANDS_COMPLETE</constant>
+                    </para>
+                </listitem>
+            </varlistentry>
+        </variablelist>
+        <para>
+            When a fence sync object is created, <function>eglCreateSync</function> also inserts a
+            fence command into the command stream of the bound client API's current
+            context (i.e., the context returned by <function>eglGetCurrentContext</function>), and
+            associates it with the newly created sync object.
+        </para>
+        <para>
+            The only condition supported for fence sync objects is
+            <constant>EGL_SYNC_PRIOR_COMMANDS_COMPLETE</constant>, which is satisfied by completion of
+            the fence command corresponding to the sync object, and all preceding
+            commands in the associated client API context's command stream. The sync
+            object will not be signaled until all effects from these commands on the
+            client API's internal and framebuffer state are fully realized. No other
+            state is affected by execution of the fence command.
+        </para>
+        <para>
+            Creation of fence sync objects requires support from the bound
+            client API, and will not succeed unless the client API satisfies
+            one of the following properties. Note that
+            <function>eglWaitSync</function> also requires satisfying these
+            conditions.
+        </para>
+        <para>
+            <itemizedlist>
+            <listitem>
+                <para>
+                    client API is OpenGL, and either the OpenGL version is
+                    3.2 or greater, or the <constant>GL_ARB_sync</constant>
+                    extension is supported.
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    client API is OpenGL ES, and either the OpenGL ES
+                    version is 3.0 or greater, or the
+                    <constant>GL_OES_EGL_sync</constant> extension is
+                    supported.
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    client API is OpenVG, and the
+                    <constant>VG_KHR_EGL_sync</constant> extension is
+                    supported.
+                </para>
+            </listitem>
+            </itemizedlist>
+        </para>
+    </refsect1>
+    <refsect1 xml:id="openclsync"><title>Creating OpenCL Event Sync Objects</title>
+        <para>
+            If <parameter>type</parameter> is
+            <constant>EGL_SYNC_CL_EVENT</constant>, an OpenCL event sync
+            object is created. In this case
+            <parameter>attrib_list</parameter> must contain the attribute
+            <constant>EGL_CL_EVENT_HANDLE</constant>, set to a valid OpenCL
+            event handle returned by a call to
+            <function>clEnqueueReleaseGLObjects</function> or
+            <function>clEnqueueReleaseEGLObjects</function>; other types of
+            OpenCL event handles are not supported. Note that
+            <constant>EGL_CL_EVENT_HANDLE</constant> is not a queriable
+            property of a sync object. Attributes of the OpenCL event sync
+            object, and their initial values, are:
+        </para>
+        <variablelist>
+            <varlistentry>
+                <term><constant>EGL_SYNC_TYPE</constant></term>
+                <listitem>
+                    <para>
+                        <constant>EGL_SYNC_CL_EVENT</constant>
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_SYNC_STATUS</constant></term>
+                <listitem>
+                    <para>
+                        Depends on status of <parameter>event</parameter>
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_SYNC_CONDITION</constant></term>
+                <listitem>
+                    <para>
+                        <constant>EGL_SYNC_CL_EVENT_COMPLETE</constant>
+                    </para>
+                </listitem>
+            </varlistentry>
+        </variablelist>
+        <para>
+            The status of such a sync object depends on
+            <parameter>event</parameter>. When the status of
+            <parameter>event</parameter> is <constant>CL_QUEUED</constant>,
+            <constant>CL_SUBMITTED</constant>, or
+            <constant>CL_RUNNING</constant>, the status of the linked sync
+            object will be <constant>EGL_UNSIGNALED</constant>. When the
+            status of <parameter>event</parameter> changes to
+            <constant>CL_COMPLETE</constant>, the status of the linked sync
+            object will become <constant>EGL_SIGNALED</constant>.
+        </para>
+        <para>
+            The only condition supported for OpenCL event sync objects is
+            <constant>EGL_SYNC_CL_EVENT_COMPLETE</constant>, which is
+            satisfied when the status of the OpenCL event associated with
+            the sync object changes to <constant>CL_COMPLETE</constant>.
+        </para>
+        <para>
+            Creating a linked sync object places a reference on the linked
+            OpenCL event object. When the sync object is deleted, the
+            reference will be removed from the event object.
+        </para>
+        <para>
+            However, implementations are not required to validate the OpenCL
+            event, and passing an invalid event handle in
+            <parameter>attrib_list</parameter> may result in undefined
+            behavior up to and including program termination.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglCreateSync</function> is supported only if the EGL
+            version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            <function>eglCreateSync</function> returns
+            <constant>EGL_NO_SYNC</constant> on failure.
+        </para>
+        <para>
+            If <parameter>display</parameter> is not the name of a valid,
+            initialized <type>EGLDisplay</type>, an
+            <constant>EGL_BAD_DISPLAY</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>attrib_list</parameter> contains an attribute name
+            not defined for the type of sync object being created, an
+            <constant>EGL_BAD_ATTRIBUTE</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>type</parameter> is not a supported type of sync
+            object, an <constant>EGL_BAD_PARAMETER</constant> error is
+            generated.
+        </para>
+        <para>
+            If <parameter>type</parameter> is
+            <constant>EGL_SYNC_FENCE</constant> and no context is current
+            for the bound API (i.e.,
+            <function>eglGetCurrentContext</function> returns
+            <constant>EGL_NO_CONTEXT</constant>), an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>type</parameter> is
+            <constant>EGL_SYNC_FENCE</constant> and
+            <parameter>display</parameter> does not match the
+            <type>EGLDisplay</type> of the currently bound context for the
+            currently bound client API (the <type>EGLDisplay</type> returned
+            by <function>eglGetCurrentDisplay</function>), an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>type</parameter> is
+            <constant>EGL_SYNC_FENCE</constant> and the current context for
+            the currently bound client API does not support fence commands,
+            an <constant>EGL_BAD_MATCH</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>type</parameter> is
+            <constant>EGL_SYNC_CL_EVENT</constant> and
+            <constant>EGL_CL_EVENT_HANDLE</constant> is not specified in
+            <parameter>attrib_list</parameter>, or its attribute value is
+            not a valid OpenCL event handle as described above, then an
+            <constant>EGL_BAD_ATTRIBUTE</constant> error is generated.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <function>clEnqueueReleaseGLObjects</function>,
+            <function>clEnqueueReleaseEGLObjects</function>,
+            <citerefentry><refentrytitle>eglClientWaitSync</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglCreateSync</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglGetCurrentContext</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglGetCurrentDisplay</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglWaitSync</refentrytitle></citerefentry>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/eglCreateWindowSurface.xml
+++ b/sdk/docs/man/eglCreateWindowSurface.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglCreateWindowSurface">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -56,174 +56,26 @@
     </refsect1>
     <refsect1 xml:id="description"><title>Description</title>
         <para>
-            <function>eglCreateWindowSurface</function> creates an EGL
-            window surface and returns its handle. If
-            <function>eglCreateWindowSurface</function> fails to create
-            a window surface, <constant>EGL_NO_SURFACE</constant> is
-            returned.
-        </para>
-        <para>
-            Surface attributes are specified as a list of
-            attribute-value pairs, terminated with
-            <constant>EGL_NONE</constant>. Accepted attributes
-            are:
-        </para>
-        <variablelist>
-            <varlistentry>
-                <term><constant>EGL_RENDER_BUFFER</constant></term>
-                <listitem>
-                <para>
-                    Specifies which buffer should be used for client API
-                    rendering to the window. If its value is
-                    <constant>EGL_SINGLE_BUFFER</constant>, then client
-                    APIs should render directly into the visible window.
-                    If its value is
-                    <constant>EGL_BACK_BUFFER</constant>, then client
-                    APIs should render into the back buffer. The default
-                    value of <constant>EGL_RENDER_BUFFER</constant> is
-                    <constant>EGL_BACK_BUFFER</constant>.
-                </para>
-                <para>
-                    Client APIs may not be able to respect the requested
-                    rendering buffer. To determine the actual buffer
-                    being rendered to by a context, call
-                    <citerefentry><refentrytitle>eglQueryContext</refentrytitle></citerefentry>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_VG_ALPHA_FORMAT</constant></term>
-                <listitem>
-                <para>
-                    Specifies how alpha values are interpreted by OpenVG
-                    when rendering to the surface. If its value is
-                    <constant>EGL_VG_ALPHA_FORMAT_NONPRE</constant>,
-                    then alpha values are not premultipled. If its value
-                    is <constant>EGL_VG_ALPHA_FORMAT_PRE</constant>,
-                    then alpha values are premultiplied. The default
-                    value of <constant>EGL_VG_ALPHA_FORMAT</constant> is
-                    <constant>EGL_VG_ALPHA_FORMAT_NONPRE</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
-                <term><constant>EGL_VG_COLORSPACE</constant></term>
-                <listitem>
-                <para>
-                    Specifies the color space used by OpenVG when
-                    rendering to the surface. If its value is
-                    <constant>EGL_VG_COLORSPACE_sRGB</constant>, then a
-                    non-linear, perceptually uniform color space is
-                    assumed, with a corresponding
-                    <type>VGImageFormat</type> of form
-                    <constant>VG_s*</constant>. If its value is
-                    <constant>EGL_VG_COLORSPACE_LINEAR</constant>, then
-                    a linear color space is assumed, with a
-                    corresponding <type>VGImageFormat</type> of form
-                    <constant>VG_l*</constant>. The default value of
-                    <constant>EGL_VG_COLORSPACE</constant> is
-                    <constant>EGL_VG_COLORSPACE_sRGB</constant>.
-                </para>
-                </listitem>
-            </varlistentry>
-        </variablelist>
-        <para>
-            Any EGL rendering context that was created with respect to
-            <parameter>config</parameter> can be used to render into the
-            surface. Use
-            <citerefentry><refentrytitle>eglMakeCurrent</refentrytitle></citerefentry>
-            to attach an EGL rendering context to the surface.
-        </para>
-        <para>
-            Use
-            <citerefentry><refentrytitle>eglQuerySurface</refentrytitle></citerefentry>
-            to retrieve the ID of <parameter>config</parameter>.
-        </para>
-        <para>
-            Use
-            <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>
-            to destroy the surface.
-        </para>
-    </refsect1>
-    <refsect1 xml:id="notes"><title>Notes</title>
-        <para>
-            Attributes <constant>EGL_RENDER_BUFFER</constant>,
-            <constant>EGL_VG_ALPHA_FORMAT</constant>, and
-            <constant>EGL_VG_COLORSPACE</constant>, and the
-            corresponding attribute values, are supported only if the
-            EGL version is 1.2 or greater.
-        </para>
-        <!-- Might want to mention aliasing of EGL_VG_* -> EGL_* that occurred in EGL 1.3 -->
-        <para>
-            The <constant>EGL_VG_ALPHA_FORMAT</constant> and
-            <constant>EGL_VG_COLORSPACE</constant> attributes are used
-            only by OpenVG. EGL itself, and other client APIs such as
-            OpenGL and OpenGL ES , do not distinguish multiple
-            colorspace models. Refer to section 11.2 of the OpenVG 1.0
-            specification for more information. The native window
-            system's use and interpretation of alpha values is outside
-            the scope of EGL, although the preferred behavior is for the
-            window system to ignore the value of
-            <constant>EGL_VG_ALPHA_FORMAT</constant> when compositing
-            window surfaces.
+            <function>eglCreateWindowSurface</function> creates an on-screen
+            EGL window surface and returns a handle to it. The behavior of
+            <function>eglCreateWindowSurface</function> is identical to that
+            of
+            <citerefentry><refentrytitle>eglCreatePlatformWindowSurface</refentrytitle></citerefentry>
+            except that the set of platforms to which
+            <parameter>display</parameter> is permitted to belong, as well
+            as the actual type of <parameter>native_window</parameter>, are
+            implementation specific.
         </para>
     </refsect1>
     <refsect1 xml:id="errors"><title>Errors</title>
         <para>
-            <constant>EGL_NO_SURFACE</constant> is returned if creation of
-            the context fails.
-        </para>
-        <para>
-            <constant>EGL_BAD_DISPLAY</constant> is generated if
-            <parameter>display</parameter> is not an EGL display connection.
-        </para>
-        <para>
-            <constant>EGL_NOT_INITIALIZED</constant> is generated if
-            <parameter>display</parameter> has not been initialized.
-        </para>
-        <para>
-            <constant>EGL_BAD_CONFIG</constant> is generated if
-            <parameter>config</parameter> is not an EGL frame buffer configuration.
-        </para>
-        <para>
-            <constant>EGL_BAD_NATIVE_WINDOW</constant> may be generated if
-            <parameter>native_window</parameter> is not a valid native window.
-        </para>
-        <para>
-            <constant>EGL_BAD_ATTRIBUTE</constant> is generated if
-            <parameter>attrib_list</parameter> contains an invalid window attribute
-            or if an attribute value is not recognized or is out of range.
-        </para>
-        <para>
-            <constant>EGL_BAD_ALLOC</constant> is generated if there are not
-            enough resources to allocate the new surface.
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if the attributes of
-            <parameter>native_window</parameter> do not correspond to
-            <parameter>config</parameter> or if
-            <parameter>config</parameter> does not support rendering to windows
-            (the <constant>EGL_SURFACE_TYPE</constant> attribute does not contain
-            <constant>EGL_WINDOW_BIT</constant>).
-        </para>
-        <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if
-            <parameter>config</parameter> does not support the specified
-            OpenVG alpha format attribute (the value of
-            <constant>EGL_VG_ALPHA_FORMAT</constant> is
-            <constant>EGL_VG_ALPHA_FORMAT_PRE</constant> and the
-            <constant>EGL_VG_ALPHA_FORMAT_PRE_BIT</constant> is not set
-            in the <constant>EGL_SURFACE_TYPE</constant> attribute of
-            <parameter>config</parameter>) or colorspace attribute (the
-            value of <constant>EGL_VG_COLORSPACE</constant> is
-            <constant>EGL_VG_COLORSPACE_LINEAR</constant> and the
-            <constant>EGL_VG_COLORSPACE_LINEAR_IT</constant> is not set
-            in the <constant>EGL_SURFACE_TYPE</constant> attribute of
-            <parameter>config</parameter>).
+            See errors for
+            <citerefentry><refentrytitle>eglCreatePlatformWindowSurface</refentrytitle></citerefentry>.
         </para>
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>
         <para>
+            <citerefentry><refentrytitle>eglCreatePlatformWindowSurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglChooseConfig</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglGetConfigs</refentrytitle></citerefentry>,

--- a/sdk/docs/man/eglDestroyImage.xml
+++ b/sdk/docs/man/eglDestroyImage.xml
@@ -34,7 +34,7 @@
                 </para></listitem>
             </varlistentry>
             <varlistentry>
-                <term><parameter>sync</parameter></term>
+                <term><parameter>image</parameter></term>
                 <listitem><para>
                     Specifies the image to destroy.
                 </para></listitem>

--- a/sdk/docs/man/eglDestroyImage.xml
+++ b/sdk/docs/man/eglDestroyImage.xml
@@ -1,0 +1,85 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglDestroyImage">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglDestroyImage</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglDestroyImage</refname>
+        <refpurpose>
+            Destroy an <type>EGLImage</type> object
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+            <funcdef>EGLBoolean <function>eglDestroyImage</function></funcdef>
+            <paramdef>(EGLDisplay <parameter>display</parameter></paramdef>
+            <paramdef>EGLImage <parameter>image</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>display</parameter></term>
+                <listitem><para>
+                    Specifies the <acronym>EGL</acronym> display connection.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>sync</parameter></term>
+                <listitem><para>
+                    Specifies the image to destroy.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <function>eglDestroyImage</function> is used to destroy the
+            specified <type>EGLImage</type> object
+            <parameter>image</parameter>. Once destroyed,
+            <parameter>image</parameter> may not be used to create any
+            additional <type>EGLImage</type> target resources within any
+            client API contexts, although existing <type>EGLImage</type>
+            siblings may continue to be used. <constant>EGL_TRUE</constant>
+            is returned on success.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            On failure, <function>eglDestroyImage</function> returns
+            <constant>EGL_FALSE</constant>
+        </para>
+        <para>
+            If <parameter>display</parameter> is not the handle of a valid
+            <type>EGLDisplay</type> object, the error
+            <constant>EGL_BAD_DISPLAY</constant> is generated.
+        </para>
+        <para>
+            If <parameter>image</parameter> is not a valid
+            <type>EGLImage</type> object created with respect to
+            <parameter>display</parameter>, the error
+            <constant>EGL_BAD_PARAMETER</constant> is generated.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglDestroyImage</function> is available only if the
+            EGL version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>eglCreateImage</refentrytitle></citerefentry>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/eglDestroySync.xml
+++ b/sdk/docs/man/eglDestroySync.xml
@@ -1,0 +1,98 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglDestroySync">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglDestroySync</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglDestroySync</refname>
+        <refpurpose>
+            Destroy a sync object
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+            <funcdef>EGLBoolean <function>eglDestroySync</function></funcdef>
+            <paramdef>(EGLDisplay <parameter>display</parameter></paramdef>
+            <paramdef>EGLSync <parameter>sync</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>display</parameter></term>
+                <listitem><para>
+                    Specifies the <acronym>EGL</acronym> display connection.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>sync</parameter></term>
+                <listitem><para>
+                    Specifies the sync object to destroy.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <function>eglDestroySync</function> is used to destroy an
+            existing sync object.
+        </para>
+        <para>
+            If any <function>eglClientWaitSync</function> or
+            <function>eglWaitSync</function> commands are blocking on
+            <parameter>sync</parameter> when
+            <function>eglDestroySync</function> is called,
+            <parameter>sync</parameter> is flagged for deletion and will be
+            deleted when the associated fence command or OpenCL event object
+            has completed, and <parameter>sync</parameter> is no longer
+            blocking any such <function>egl*WaitSync</function> command.
+            Otherwise, the sync object is destroyed immediately.
+        </para>
+        <para>
+            If no errors are generated, <constant>EGL_TRUE</constant> is
+            returned, and <parameter>sync</parameter> will no longer be the
+            handle of a valid sync object.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            On failure, <function>eglDestroySync</function> returns
+            <constant>EGL_FALSE</constant>.
+        </para>
+        <para>
+            If <parameter>sync</parameter> is not a valid sync object for
+            <parameter>display</parameter>, <constant>EGL_FALSE</constant>
+            is returned and an <constant>EGL_BAD_PARAMETER</constant> error
+            is generated.
+        </para>
+        <para>
+            If <parameter>display</parameter> does not match the display
+            passed to <function>eglCreateSync</function> when
+            <parameter>sync</parameter> was created, the behaviour is
+            undefined.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglDestroySync</function> is available only if the EGL
+            version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>eglClientWaitSync</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglCreateSync</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglWaitSync</refentrytitle></citerefentry>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/eglGetCurrentDisplay.xml
+++ b/sdk/docs/man/eglGetCurrentDisplay.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglGetCurrentDisplay">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -31,6 +31,20 @@
             <acronym>EGL</acronym> rendering context, as specified by
             <citerefentry><refentrytitle>eglMakeCurrent</refentrytitle></citerefentry>.
             If no context is current, <constant>EGL_NO_DISPLAY</constant> is returned.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            Passing <constant>EGL_NO_DISPLAY</constant> to any command
+            taking an <type>EGLDisplay</type> parameter will generate either
+            an <constant>EGL_BAD_DISPLAY</constant> error if the EGL
+            implementation validates <type>EGLDisplay</type> handles, or
+            undefined behavior as described at the end of section 3.1 of the
+            EGL 1.5 Specification. The only exception to this rule is that
+            <function>eglQueryString</function> will accept an
+            <type>EGLDisplay</type> parameter of
+            <constant>EGL_NO_DISPLAY</constant> when querying the client
+            extension string (see section 3.3 of the EGL 1.5 Specification).
         </para>
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>

--- a/sdk/docs/man/eglGetDisplay.xml
+++ b/sdk/docs/man/eglGetDisplay.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglGetDisplay">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -44,6 +44,26 @@
             display <parameter>native_display</parameter>.
         </para>
         <para>
+            The behavior of <function>eglGetDisplay</function> is similar to
+            that of
+            <citerefentry><refentrytitle>eglGetPlatformDisplay</refentrytitle></citerefentry>,
+            but is specified in terms of implementation-specific behavior
+            rather than platform-specific extensions. As for
+            <citerefentry><refentrytitle>eglGetPlatformDisplay</refentrytitle></citerefentry>,
+            EGL considers the returned <type>EGLDisplay</type> as belonging
+            to the same platform as <parameter>display_id</parameter>.
+            However, the set of platforms to which
+            <parameter>display_id</parameter> is permitted to belong, as
+            well as the actual type of <parameter>display_id</parameter>,
+            are implementation-specific. If
+            <parameter>display_id</parameter> is
+            <constant>EGL_DEFAULT_DISPLAY</constant>, a <firstterm>default
+            display</firstterm> is returned. Multiple calls made to
+            <function>eglGetDisplay</function> with the same
+            <parameter>display_id</parameter> will return the same
+            <type>EGLDisplay</type> handle.
+        </para>
+        <para>
             If <parameter>display_id</parameter> is
             <constant>EGL_DEFAULT_DISPLAY</constant>, a default display connection is returned.
         </para>
@@ -59,7 +79,8 @@
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>
         <para>
-            <citerefentry><refentrytitle>eglInitialize</refentrytitle></citerefentry>
+            <citerefentry><refentrytitle>eglInitialize</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglGetPlatformDisplay</refentrytitle></citerefentry>
         </para>
     </refsect1>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>

--- a/sdk/docs/man/eglGetError.xml
+++ b/sdk/docs/man/eglGetError.xml
@@ -31,6 +31,13 @@
             Initially, the error is set to <constant>EGL_SUCCESS</constant>.
         </para>
         <para>
+            When an EGL function could potentially generate several
+            different errors (for example, when passed both a bad attribute
+            name, and a bad attribute value for a legal attribute name), the
+            implementation may choose to generate any one of the applicable
+            errors.
+        </para>
+        <para>
             The following errors are currently defined:
         </para>
         <variablelist>

--- a/sdk/docs/man/eglGetPlatformDisplay.xml
+++ b/sdk/docs/man/eglGetPlatformDisplay.xml
@@ -1,0 +1,122 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglGetPlatformDisplay">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglGetPlatformDisplay</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglGetPlatformDisplay</refname>
+        <refpurpose>
+            return an <acronym>EGL</acronym> display connection
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+                <funcdef>EGLDisplay <function>eglGetPlatformDisplay</function></funcdef>
+                <paramdef>EGLenum <parameter>platform</parameter></paramdef>
+                <paramdef>void * <parameter>native_display</parameter></paramdef>
+                <paramdef>const EGLAttrib * <parameter>attrib_list</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>platform</parameter></term>
+                <listitem>
+                    <para>
+                        Specifies the native platform to obtain a display for.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>native_display</parameter></term>
+                <listitem>
+                    <para>
+                        Specifies the native display to connect to.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>attrib_list</parameter></term>
+                <listitem>
+                    <para>
+                        Specifies attributes of the display being obtained.
+                    </para>
+                </listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <function>eglGetPlatformDisplay</function> obtains an
+            <acronym>EGL</acronym> display connection for the specified
+            <parameter>platform</parameter> and
+            <parameter>native_display</parameter>.
+        </para>
+        <para>
+            Valid values for <parameter>platform</parameter> are defined by
+            EGL extensions, as are requirements for
+            <parameter>native_display</parameter>.
+            For example, an extension specification that defines support for
+            the X11 platform may require that
+            <parameter>native_display</parameter> be a pointer to an X11
+            Display, and an extension specification that defines support for
+            the Microsoft Windows platform may require that
+            <parameter>native_display</parameter> be a pointer to a Windows
+            Device Context.
+        </para>
+        <para>
+            Valid attributes are defined by EGL extensions.
+            All attributes in <parameter>attrib_list</parameter>,
+            including boolean attributes, are immediately followed by
+            the corresponding desired value.
+            The list is terminated with <constant>EGL_NONE</constant>.
+            If an attribute is not specified in
+            <parameter>attrib_list</parameter> but is required for the
+            specified <parameter>platform</parameter>, then a default value
+            is used (and the attribute is said to be specified implicitly).
+        </para>
+        <para>
+            Multiple calls made to
+            <function>eglGetPlatformDisplay</function> with the same
+            parameters will return the same <type>EGLDisplay</type> handle.
+        </para>
+        <para>
+            If <parameter>platform</parameter> is valid but no display
+            matching <parameter>native_display</parameter> is available,
+            then <constant>EGL_NO_DISPLAY</constant> is returned; no error
+            condition is raised in this case.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglGetPlatformDisplay</function> is supported only if
+            the EGL version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            <function>eglGetPlatformDisplay</function> returns
+            <constant>EGL_NO_DISPLAY</constant> on failure.
+        </para>
+        <para>
+            An <constant>EGL_BAD_PARAMETER</constant> error is generated if
+            <parameter>platform</parameter> has an invalid value.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>eglInitialize</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglGetDisplay</refentrytitle></citerefentry>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/eglGetProcAddress.xml
+++ b/sdk/docs/man/eglGetProcAddress.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglGetProcAddress">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -40,38 +40,59 @@
     <refsect1 xml:id="description"><title>Description</title>
         <para>
             <function>eglGetProcAddress</function> returns the address of
-            the extension function named by <parameter>procname</parameter>.
-            <parameter>procname</parameter>
-            must be a null-terminated string. The pointer returned
-            should be cast to a function pointer type matching the extension
-            function's definition in that extension specification. A return value
+            the client API or EGL function named by
+            <parameter>procname</parameter>. <parameter>procname</parameter>
+            must be a null-terminated string. The pointer returned should be
+            cast to a function pointer matching the function's definition in
+            the corresponding API or extension specification. A return value
             of <constant>NULL</constant> indicates that the specific
-            function does not exist for the <acronym>EGL</acronym> implementation.
+            function does not exist for the implementation.
         </para>
         <para>
             A non-<constant>NULL</constant> return value does not guarantee
-            that an extension function is actually supported at runtime. The client
-            must also query
-            <citerefentry><refentrytitle>glGetString</refentrytitle></citerefentry>(<constant>GL_EXTENSIONS</constant>) or
-            <citerefentry><refentrytitle>eglQueryString</refentrytitle></citerefentry>(<parameter>display</parameter>,
-            <constant>EGL_EXTENSIONS</constant>) to determine if an
-            extension is supported by a particular context or display.
+            that an extension function is actually supported at runtime. The
+            client must also make a corresponding query, such as
+            <function>glGetString</function>(<constant>GL_EXTENSIONS</constant>)
+            for OpenGL and OpenGL ES extensions;
+            <function>vgGetString</function>(<constant>VG_EXTENSIONS</constant>)
+            for OpenVG extensions;
+            <function>eglQueryString</function>(<parameter>display</parameter>,
+            <constant>EGL_EXTENSIONS</constant>); or query the EGL or client
+            API version for non-extension functions, to determine if a
+            function is supported by EGL or a specific client API context.
         </para>
         <para>
-            Function pointers returned by
+            Client API function pointers returned by
             <function>eglGetProcAddress</function> are independent of the
-            display and the currently bound context and may be used by any context
-            which supports the extension.
+            display and the currently bound client API context, and may be
+            used by any client API context which supports the function.
         </para>
         <para>
             <function>eglGetProcAddress</function> may be queried for all
-            <acronym>GL</acronym> and <acronym>EGL</acronym> extension functions.
+            EGL and client API functions supported by the implementation
+            (whether those functions are extensions or not, and whether they
+            are supported by the current client API context or not).
+        </para>
+        <para>
+            For functions that are queryable with
+            <function>eglGetProcAddress</function>, implementations may
+            choose to also export those functions statically from the object
+            libraries implementing those functions. However, portable
+            clients cannot rely on this behavior.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            If the EGL version is not 1.5 or greater, only queries of EGL
+            and client API <emphasis>extension</emphasis> functions will
+            succeed.
         </para>
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>
         <para>
-            <citerefentry><refentrytitle>glGetString</refentrytitle></citerefentry>,
+            <function>glGetString</function>
             <citerefentry><refentrytitle>eglQueryString</refentrytitle></citerefentry>    </para>
+            <function>vgGetString</function>
     </refsect1>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
 </refentry>

--- a/sdk/docs/man/eglGetSyncAttrib.xml
+++ b/sdk/docs/man/eglGetSyncAttrib.xml
@@ -1,0 +1,148 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglGetSyncAttrib">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglGetSyncAttrib</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglGetSyncAttrib</refname>
+        <refpurpose>
+            Return an attribute of a sync object
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+            <funcdef>EGLBoolean <function>eglGetSyncAttrib</function></funcdef>
+            <paramdef>(EGLDisplay <parameter>display</parameter></paramdef>
+            <paramdef>EGLSync <parameter>sync</parameter></paramdef>
+            <paramdef>EGLint <parameter>attribute</parameter></paramdef>
+            <paramdef>EGLAttrib *<parameter>value</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>display</parameter></term>
+                <listitem><para>
+                    Specifies the <acronym>EGL</acronym> display connection.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>sync</parameter></term>
+                <listitem><para>
+                    Specifies the sync object to query.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>flags</parameter></term>
+                <listitem><para>
+                    Specifies the EGL sync object attribute to query.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>timeout</parameter></term>
+                <listitem><para>
+                    Returns the requested attribute value.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <function>eglGetSyncAttrib</function> is used to query
+            attributes of the sync object <parameter>sync</parameter>. Legal
+            values for <parameter>attribute</parameter> depend on the type
+            of sync object, as shown in table
+            <xref linkend="tab-syncattr"/>. Assuming no errors are
+            generated, <constant>EGL_TRUE</constant> is returned and the
+            value of the queried attribute is returned in
+            *<parameter>value</parameter>.
+        </para>
+        <table frame="all" xml:id="tab-syncattr">
+            <title>
+                Attributes accepted by <function>eglGetSyncAttrib</function>
+            </title>
+            <tgroup cols="3" align="left" colsep="1" rowsep="1">
+                <thead>
+                    <row>
+                        <entry>Attribute</entry>
+                        <entry>Description</entry>
+                        <entry>Supported Sync Objects</entry>
+                    </row>
+                </thead>
+                <tbody>
+                    <row>
+                        <entry>Attribute</entry>
+                        <entry>Description</entry>
+                        <entry>Supported Sync Objects</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_SYNC_TYPE</constant></entry>
+                        <entry>Type of the sync object</entry>
+                        <entry>All</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_SYNC_STATUS</constant></entry>
+                        <entry>Status of the sync object</entry>
+                        <entry>All</entry>
+                    </row>
+                    <row>
+                        <entry><constant>EGL_SYNC_CONDITION</constant></entry>
+                        <entry>Signaling condition</entry>
+                        <entry>
+                            <constant>EGL_SYNC_FENCE</constant> or
+                            <constant>EGL_SYNC_CL_EVENT</constant>
+                        </entry>
+                    </row>
+                </tbody>
+            </tgroup>
+        </table>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            On failure, <function>eglGetSyncAttrib</function> returns
+            <constant>EGL_FALSE</constant> and *<parameter>value</parameter>
+            is not modified.
+        </para>
+        <para>
+            If <parameter>sync</parameter> is not a valid sync object for
+            <parameter>display</parameter>, an
+            <constant>EGL_BAD_PARAMETER</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>attribute</parameter> is not one of the attributes
+            in table <xref linkend="tab-syncattr"/>, an
+            <constant>EGL_BAD_ATTRIBUTE</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>attribute</parameter> is not supported for the
+            type of sync object passed in <parameter>sync</parameter>, an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>display</parameter> does not match the display
+            passed to <function>eglCreateSync</function> when
+            <parameter>sync</parameter> was created, behaviour is undefined.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglGetSyncAttrib</function> is available only if the
+            EGL version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>eglCreateSync</refentrytitle></citerefentry>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/eglGetSyncAttrib.xml
+++ b/sdk/docs/man/eglGetSyncAttrib.xml
@@ -42,13 +42,13 @@
                 </para></listitem>
             </varlistentry>
             <varlistentry>
-                <term><parameter>flags</parameter></term>
+                <term><parameter>attribute</parameter></term>
                 <listitem><para>
                     Specifies the EGL sync object attribute to query.
                 </para></listitem>
             </varlistentry>
             <varlistentry>
-                <term><parameter>timeout</parameter></term>
+                <term><parameter>value</parameter></term>
                 <listitem><para>
                     Returns the requested attribute value.
                 </para></listitem>

--- a/sdk/docs/man/eglIntro.xml
+++ b/sdk/docs/man/eglIntro.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglIntro">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -23,28 +23,39 @@
             using a <firstterm>client API</firstterm> such as OpenGL ES
             (a 3D renderer for embedded systems), OpenGL (a functional
             superset of OpenGL ES for desktop systems), and OpenVG (a 2D
-            vector graphics renderer) together with a native window
-            system, such as Microsoft Windows or the X Window System.
+            vector graphics renderer) together with a
+            <firstterm>platform</firstterm>, such as Microsoft Windows or
+            the X Window System.
         </para>
         <para>
             Depending on its implementation EGL might be more or less
-            tightly integrated into the native window system. Most EGL
+            tightly integrated into the platform. Most EGL
             functions require an EGL display connection, which can be
             obtained by calling
-            <citerefentry><refentrytitle>eglGetDisplay</refentrytitle></citerefentry>
-            and passing in a native display handle or
-            <constant>EGL_DEFAULT_DISPLAY</constant>. To initialize and
+            <citerefentry><refentrytitle>eglGetPlatformDisplay</refentrytitle></citerefentry>
+            or
+            <citerefentry><refentrytitle>eglGetDisplay</refentrytitle></citerefentry>.
+            To initialize and
             query what EGL version is supported on the display
             connection, call
             <citerefentry><refentrytitle>eglInitialize</refentrytitle></citerefentry>.
         </para>
         <para>
-            Native window systems supporting EGL make a subset of their
+            The EGL specification does not define the set of platforms that
+            may be supported by an EGL implementation, nor does it specify
+            behavior specific to any platform. The set of supported
+            platforms and their behavior is defined by platform-specific
+            extensions. To detect if a particular platform is supported,
+            clients should query the <constant>EGL_EXTENSIONS</constant>
+            string of <constant>EGL_NO_DISPLAY</constant> using
+            <citerefentry><refentrytitle>eglQueryString</refentrytitle></citerefentry>.
+        </para>
+        <para>
+            Platforms supporting EGL make a subset of their
             visuals (which may also referred to as pixel formats, frame
             buffer configurations, or other similar terms) available for
             client API rendering. Windows and pixmaps created with these
-            visuals may also be rendered into using the native window
-            system API.
+            visuals may also be rendered into using the platform APIs.
         </para>
         <para>
             An EGL <firstterm>surface</firstterm> extends a native
@@ -58,9 +69,9 @@
             EGL supports rendering into three types of surfaces:
             windows, pixmaps and pixel buffers (pbuffers). EGL window
             and pixmap surfaces are associated with corresponding
-            resources of the native window system. EGL pixel buffers are
-            EGL only resources, and do not accept rendering through the
-            native window system.
+            resources of the platform. EGL pixel buffers are
+            EGL-only resources, and do not accept rendering through the
+            platform APIs.
         </para>
         <para>
             To render using a client API into an EGL surface, you must
@@ -122,13 +133,13 @@
             is called with different arguments.
         </para>
         <para>
-            Both native and client API commands may be used to operate
-            on certain surfaces, however, the two command streams are
+            Both platform and client API commands may be used to operate
+            on certain surfaces. However, the two command streams are
             not synchronized. Synchronization can be explicitly
             specified using by calling
-            <citerefentry><refentrytitle>eglWaitCLient</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglWaitClient</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglWaitNative</refentrytitle></citerefentry>,
-            and possibly by calling other native window system commands.
+            and possibly by calling other platform APIs.
         </para>
     </refsect1>
     <refsect1 xml:id="examples"><title>Examples</title>
@@ -183,10 +194,18 @@ int main(int argc, char ** argv)
 }
 </programlisting>
     </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            Prior to EGL 1.5, platforms were referred to as the
+            <firstterm>native window system</firstterm>, and
+            platform-specific queries and APIs were not available. Only a
+            single native window system was supported.
+        </para>
+    </refsect1>
     <refsect1 xml:id="usingeglextensions"><title>Using EGL Extensions</title>
         <para>
             All supported EGL extensions will have a corresponding definition in
-            <filename>egl.h</filename> and a token in the extensions string returned
+            <filename>egl.h</filename> and a token in the extension strings returned
             by
             <citerefentry><refentrytitle>eglQueryString</refentrytitle></citerefentry>.
         </para>
@@ -232,6 +251,7 @@ int main(int argc, char ** argv)
             <citerefentry><refentrytitle>eglDestroySurface</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglGetConfigs</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglGetDisplay</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglGetPlatformDisplay</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglInitialize</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglMakeCurrent</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>eglQueryString</refentrytitle></citerefentry>,

--- a/sdk/docs/man/eglMakeCurrent.xml
+++ b/sdk/docs/man/eglMakeCurrent.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglMakeCurrent">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -61,31 +61,113 @@
         <para>
             <function>eglMakeCurrent</function> binds <parameter>context</parameter>
             to the current rendering thread and to the <parameter>draw</parameter>
-            and <parameter>read</parameter> surfaces. <parameter>draw</parameter>
-            is used for all GL operations except for any pixel data read back
+            and <parameter>read</parameter> surfaces.
+        </para>
+        <para>
+            For an OpenGL or OpenGL ES context, <parameter>draw</parameter>
+            is used for all operations except for any pixel data read back or copied
             (<citerefentry><refentrytitle>glReadPixels</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>glCopyTexImage2D</refentrytitle></citerefentry>, and
             <citerefentry><refentrytitle>glCopyTexSubImage2D</refentrytitle></citerefentry>),
             which is taken from the frame buffer values of
+            <parameter>read</parameter>. Note that the same
+            <type>EGLSurface</type> may be specified for both draw and read.
+        </para>
+        <para>
+            For an OpenVG context, the same <type>EGLSurface</type> must be
+            specified for both <parameter>draw</parameter> and
             <parameter>read</parameter>.
         </para>
         <para>
-            If the calling thread has already a current rendering context, that
-            context is flushed and marked as no longer current.
+            If the calling thread has already a current rendering context of
+            the same client API type as <parameter>context</parameter>, then
+            that context is flushed and marked as no longer current.
+            <parameter>context</parameter> is then made the current context
+            for the calling thread. For purposes of
+            <function>eglMakeCurrent</function>, the client API type of all
+            OpenGL ES and OpenGL contexts is considered the same. In other
+            words, if any OpenGL ES context is currently bound and
+            <parameter>context</parameter> is an OpenGL context, or if any
+            OpenGL context is currently bound and
+            <parameter>context</parameter> is an OpenGL ES context, the
+            currently bound context will be made no longer current and
+            <parameter>context</parameter> will be made current.
         </para>
         <para>
-            The first time that <parameter>context</parameter> is made current,
-            the viewport and scissor dimensions are set to the size of the
-            <parameter>draw</parameter> surface. The viewport and
-            scissor are not modified when <parameter>context</parameter> is
-            subsequently made current.
+            OpenGL and OpenGL ES buffer mappings created by e.g.
+            <function>glMapBuffer</function> are not affected by
+            <function>eglMakeCurrent</function>; they persist whether the
+            context owning the buffer is current or not.
         </para>
         <para>
-            To release the current context without assigning a new one, call
-            <function>eglMakeCurrent</function> with <parameter>draw</parameter>
-            and <parameter>read</parameter> set to
-            <constant>EGL_NO_SURFACE</constant> and <parameter>context</parameter>
-            set to <constant>EGL_NO_CONTEXT</constant>.
+            If <parameter>draw</parameter> is destroyed after
+            <function>eglMakeCurrent</function> is called, then subsequent
+            rendering commands will be processed and the context state will
+            be updated, but the surface contents become undefined. If
+            <parameter>read</parameter> is destroyed after
+            <function>eglMakeCurrent</function> then pixel values
+            <parameter>read</parameter> from the framebuffer (e.g., as
+            result of calling glReadPixels) are undefined. If a native
+            window or pixmap underlying the <parameter>draw</parameter> or
+            <parameter>read</parameter> surfaces is destroyed, rendering and
+            <parameter>read</parameter>back are handled as above.
+        </para>
+        <para>
+            To release the current context without assigning a new one, set
+            <parameter>context</parameter> to
+            <constant>EGL_NO_CONTEXT</constant> and set
+            <parameter>draw</parameter> and <parameter>read</parameter> to
+            <constant>EGL_NO_SURFACE</constant> . The currently bound
+            context for the client API specified by the current rendering
+            API is flushed and marked as no longer current, and there will
+            be no current context for that client API after
+            <function>eglMakeCurrent</function> returns. This is the only
+            case in which <function>eglMakeCurrent</function> respects the
+            current rendering API. In all other cases, the client API
+            affected is determined by <parameter>context</parameter>. This
+            is the only case where an uninitialized display may be passed to
+            <function>eglMakeCurrent</function>.
+        </para>
+        <para>
+            If ctx is not <constant>EGL_NO_CONTEXT</constant>, then both
+            <parameter>draw</parameter> and <parameter>read</parameter> must
+            not be <constant>EGL_NO_SURFACE</constant> unless
+            <parameter>context</parameter> is a context which supports being
+            bound without read and draw surfaces. In this case the context
+            is made current without a default framebuffer. The meaning of
+            this is defined by the client API of the supporting context (see
+            chapter 4 of the OpenGL 3.0 Specification, and the
+            <constant>GL_OES_surfaceless_context</constant> OpenGL ES
+            extension.).
+        </para>
+        <para>
+            The first time a OpenGL or OpenGL ES context is made current the
+            viewport and scissor dimensions are set to the size of the
+            <parameter>draw</parameter> surface (as though
+            <function>glViewport</function>(0,0,w,h) and
+            <function>glScissor</function>(0,0,<parameter>w</parameter>,<parameter>h</parameter>)
+            were called, where <parameter>w</parameter> and
+            <parameter>h</parameter> are the width and height of the
+            surface, respectively). However, the viewport and scissor
+            dimensions are not modified when <parameter>context</parameter>
+            is subsequently made current. The client is responsible for
+            resetting the viewport and scissor in this case.
+        </para>
+        <para>
+            The first time <parameter>context</parameter> is made current,
+            if it is without a default framebuffer (e.g. both
+            <parameter>draw</parameter> and <parameter>read</parameter> are
+            <constant>EGL_NO_SURFACE</constant> ), then the viewport and
+            scissor regions are set as though
+            <function>glViewport</function>(0,0,0,0) and
+            <function>glScissor</function>(0,0,0,0) were called.
+        </para>
+        <para>
+            Implementations may delay allocation of auxiliary buffers for a
+            surface until they are required by a context (which may result
+            in the <constant>EGL_BAD_ALLOC</constant> error described
+            above). Once allocated, however, auxiliary buffers and their
+            contents persist until a surface is deleted.
         </para>
         <para>
             Use
@@ -97,81 +179,126 @@
     </refsect1>
     <refsect1 xml:id="errors"><title>Errors</title>
         <para>
-            <constant>EGL_FALSE</constant> is returned on failure,
-            <constant>EGL_TRUE</constant> otherwise. If <constant>EGL_FALSE</constant>
-            is returned, the previously current rendering context and
-            surfaces (if any) remain unchanged.
+            If <parameter>draw</parameter> or <parameter>read</parameter>
+            are not compatible with <parameter>context</parameter>, then an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_BAD_DISPLAY</constant> is generated if
-            <parameter>display</parameter> is not an EGL display connection.
+            If <parameter>context</parameter> is current to some other
+            thread, or if either <parameter>draw</parameter> or
+            <parameter>read</parameter> are bound to contexts in another
+            thread, an <constant>EGL_BAD_ACCESS</constant> error is
+            generated.
         </para>
         <para>
-            <constant>EGL_NOT_INITIALIZED</constant> is generated if
-            <parameter>display</parameter> has not been initialized.
+            If binding <parameter>context</parameter> would exceed the
+            number of current contexts of that client API type supported by
+            the implementation, an <constant>EGL_BAD_ACCESS</constant> error
+            is generated.
         </para>
         <para>
-            <constant>EGL_BAD_SURFACE</constant> is generated if
-            <parameter>draw</parameter> or <parameter>read</parameter> is not an
-            EGL surface.
+            If either <parameter>draw</parameter> or
+            <parameter>read</parameter> are pbuffers created with
+            <function>eglCreatePbufferFromClientBuffer</function>, and the
+            underlying bound client API buffers are in use by the client API
+            that created them, an <constant>EGL_BAD_ACCESS</constant> error
+            is generated.
         </para>
         <para>
-            <constant>EGL_BAD_CONTEXT</constant> is generated if
-            <parameter>context</parameter> is not an EGL rendering context.
+            If <parameter>context</parameter> is not a valid context and is
+            not <constant>EGL_NO_CONTEXT</constant>, an
+            <constant>EGL_BAD_CONTEXT</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_BAD_MATCH</constant> is generated if
-            <parameter>draw</parameter> or
-            <parameter>read</parameter>
-            are not compatible with
-            <parameter>context</parameter>, or if
-            <parameter>context</parameter> is set to
-            <constant>EGL_NO_CONTEXT</constant> and
-            <parameter>draw</parameter> or
-            <parameter>read</parameter>
-            are not set to
-            <constant>EGL_NO_SURFACE</constant>, or if
-            <parameter>draw</parameter> or
-            <parameter>read</parameter> are set to
-            <constant>EGL_NO_SURFACE</constant> and
-            <parameter>context</parameter> is not set to
-            <constant>EGL_NO_CONTEXT</constant>.
+            If either <parameter>draw</parameter> or
+            <parameter>read</parameter> are not valid EGL surfaces and are
+            not <constant>EGL_NO_SURFACE</constant>, an
+            <constant>EGL_BAD_SURFACE</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_BAD_ACCESS</constant> is generated if
-            <parameter>context</parameter>
-            is current to some other thread.
+            If <parameter>context</parameter> is
+            <constant>EGL_NO_CONTEXT</constant> and either
+            <parameter>draw</parameter> or <parameter>read</parameter> are
+            not <constant>EGL_NO_SURFACE</constant>, an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_BAD_NATIVE_PIXMAP</constant> may be generated if
-            a native pixmap underlying either
-            <parameter>draw</parameter> or
-            <parameter>read</parameter>
-            is no longer valid.
+            If either of <parameter>draw</parameter> or
+            <parameter>read</parameter> is a valid surface and the other is
+            <constant>EGL_NO_SURFACE</constant>, an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_BAD_NATIVE_WINDOW</constant> may be generated if
-            a native window underlying either
-            <parameter>draw</parameter> or
-            <parameter>read</parameter>
-            is no longer valid.
+            If <parameter>context</parameter> does not support being bound
+            without <parameter>read</parameter> and
+            <parameter>draw</parameter> surfaces, and both
+            <parameter>draw</parameter> and <parameter>read</parameter> are
+            <constant>EGL_NO_SURFACE</constant>, an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_BAD_CURRENT_SURFACE</constant> is generated if
-            the previous context has unflushed commands and the previous surface
-            is no longer valid.
+            If a native window underlying either <parameter>draw</parameter>
+            or <parameter>read</parameter> is no longer valid, an
+            <constant>EGL_BAD_NATIVE_WINDOW</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_BAD_ALLOC</constant> may be generated if
-            allocation of ancillary buffers for <parameter>draw</parameter> or
-            <parameter>read</parameter> were delayed until
-            <function>eglMakeCurrent</function> is called, and there are not
-            enough resources to allocate them.
+            If <parameter>draw</parameter> and <parameter>read</parameter>
+            cannot fit into graphics memory simultaneously, an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
         </para>
         <para>
-            <constant>EGL_CONTEXT_LOST</constant> is generated if a power management
-            event has occurred. The application must destroy all contexts and
-            reinitialise OpenGL ES state and objects to continue rendering.
+            If the previous context of the calling thread has unflushed
+            commands, and the previous surface is no longer valid, an
+            <constant>EGL_BAD_CURRENT_SURFACE</constant> error is generated.
+        </para>
+        <para>
+            If the ancillary buffers for <parameter>draw</parameter> and
+            <parameter>read</parameter> cannot be allocated, an
+            <constant>EGL_BAD_ALLOC</constant> error is generated.
+        </para>
+        <para>
+            If a power management event has occurred, an
+            <constant>EGL_CONTEXT_LOST</constant> error is generated.
+        </para>
+        <para>
+            If any of the following are true:
+
+            <itemizedlist>
+            <listitem>
+                <para>
+                    <parameter>context</parameter> is not
+                    <constant>EGL_NO_CONTEXT</constant>
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    <parameter>read</parameter> is not
+                    <constant>EGL_NO_SURFACE</constant>
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    <parameter>draw</parameter> is not
+                    <constant>EGL_NO_SURFACE</constant>
+                </para>
+            </listitem>
+            </itemizedlist>
+
+            then an <constant>EGL_NOT_INITIALIZED</constant> error is
+            generated if <parameter>display</parameter> is a valid but
+            uninitialized display.
+        </para>
+        <para>
+            As with other commands taking <type>EGLDisplay</type>
+            parameters, if <parameter>display</parameter> is not a valid
+            <type>EGLDisplay</type> handle, an
+            <constant>EGL_BAD_DISPLAY</constant> error is generated. (Some
+            implementations have chosen to allow
+            <constant>EGL_NO_DISPLAY</constant> as a valid
+            <parameter>display</parameter> parameter for
+            <function>eglMakeCurrent</function>. This behavior is not
+            portable to all EGL implementations, and should be considered as
+            an undocumented vendor extension).
         </para>
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>

--- a/sdk/docs/man/eglQueryString.xml
+++ b/sdk/docs/man/eglQueryString.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglQueryString">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -12,7 +12,8 @@
     <refnamediv>
         <refname>eglQueryString</refname>
         <refpurpose>
-            return a string describing an <acronym>EGL</acronym> display connection
+            return a string describing properties of the EGL client or of an
+            <acronym>EGL</acronym> display connection
         </refpurpose>
     </refnamediv>
     <refsynopsisdiv>
@@ -52,8 +53,9 @@
     <refsect1 xml:id="description"><title>Description</title>
         <para>
             <function>eglQueryString</function> returns a pointer to a
-            static string describing an EGL display connection.
-            <parameter>name</parameter> can be one of the following:
+            static, zero-terminated string describing properties of the EGL
+            client or of an EGL display connection.
+            <parameter>name</parameter> may be one of the following:
         </para>
         <variablelist>
             <varlistentry>
@@ -61,7 +63,7 @@
                 <listitem><para>
                     Returns a string describing which client rendering
                     APIs are supported. The string contains a
-                    space-separate list of API names. The list must
+                    space-separated list of API names. The list must
                     include at least one of <code>OpenGL</code>,
                     <code>OpenGL_ES</code>, or <code>OpenVG</code>.
                     These strings correspond respectively to values
@@ -75,27 +77,61 @@
             <varlistentry>
                 <term><constant>EGL_VENDOR</constant></term>
                 <listitem><para>
-                    Returns the company responsible for this EGL implementation. This
-                    name does not change from release to release.
+                    Returns the name of the vendor responsible for this EGL
+                    implementation. The format and contents of the string
+                    are implementation-dependent.
                 </para></listitem>
             </varlistentry>
             <varlistentry>
                 <term><constant>EGL_VERSION</constant></term>
-                <listitem><para>
-                    Returns a version or release number.
-                    The <constant>EGL_VERSION</constant> string is laid out as
-                    follows:</para>
-                <para>
-                    <replaceable>major_version</replaceable>.<replaceable>minor_version</replaceable>
-                    space
-                    <replaceable>vendor_specific_info</replaceable>
-                </para></listitem>
+                <listitem>
+                    <para>
+                        Returns a version or release number. The
+                        <constant>EGL_VERSION</constant> string is laid out
+                        as follows:
+                    </para>
+                    <para>
+                        <replaceable>major_version</replaceable>.<replaceable>minor_version</replaceable>
+                        space
+                        <replaceable>vendor_specific_info</replaceable>
+                    </para>
+                    <para>
+                        Both the major and minor portions of the version
+                        number are numeric. Their values must match the
+                        <parameter>major</parameter> and
+                        <parameter>minor</parameter> values returned by
+                        <citerefentry><refentrytitle>eglInitialize</refentrytitle></citerefentry>.
+                    </para>
+                    <para>
+                        The vendor-specific information is optional; if
+                        present, its format and contents are
+                        implementation-specific.
+                    </para>
+                </listitem>
             </varlistentry>
             <varlistentry>
                 <term><constant>EGL_EXTENSIONS</constant></term>
-                <listitem><para>
-                    Returns a space separated list of supported extensions to EGL.
-                </para></listitem>
+                <listitem>
+                    <para>
+                        Returns a space separated list of supported
+                        extensions to EGL. If there are no extensions, then
+                        the empty string is returned.
+                    </para>
+                    <para>
+                        If <parameter>display</parameter> is
+                        <constant>EGL_NO_DISPLAY</constant>, then the
+                        <constant>EGL_EXTENSIONS</constant> string describes
+                        the set of supported <firstterm>client
+                        extensions</firstterm>. If
+                        <parameter>display</parameter> is a valid,
+                        initialized display, then the
+                        <constant>EGL_EXTENSIONS</constant> string describes
+                        the set of <firstterm>display extensions</firstterm>
+                        supported by that display. The set of supported
+                        client extensions is disjoint from the set of
+                        extensions supported by any given display.
+                    </para>
+                </listitem>
             </varlistentry>
         </variablelist>
     </refsect1>
@@ -104,6 +140,11 @@
             <constant>EGL_CLIENT_APIS</constant> is supported only if
             the EGL version is 1.2 or greater.
         </para>
+        <para>
+            A <parameter>display</parameter> of
+            <constant>EGL_NO_DISPLAY</constant> is supported only if the EGL
+            version is 1.5 or greater.
+        </para>
     </refsect1>
     <refsect1 xml:id="errors"><title>Errors</title>
         <para>
@@ -111,11 +152,16 @@
         </para>
         <para>
             <constant>EGL_BAD_DISPLAY</constant> is generated if
-            <parameter>display</parameter> is not an EGL display connection.
+            <parameter>display</parameter> is not an EGL display connection,
+            unless <parameter>display</parameter> is
+            <constant>EGL_NO_DISPLAY</constant> and
+            <parameter>name</parameter> is
+            <constant>EGL_EXTENSIONS</constant>.
         </para>
         <para>
             <constant>EGL_NOT_INITIALIZED</constant> is generated if
-            <parameter>display</parameter> has not been initialized.
+            <parameter>display</parameter> is a valid but uninitialized
+            EGLDisplay.
         </para>
         <para>
             <constant>EGL_BAD_PARAMETER</constant> is generated if

--- a/sdk/docs/man/eglQuerySurface.xml
+++ b/sdk/docs/man/eglQuerySurface.xml
@@ -1,7 +1,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglQuerySurface">
     <info>
          <copyright>
-             <year>2003-2014</year>
+             <year>2003-2018</year>
              <holder>The Khronos Group Inc.</holder>
          </copyright>
     </info>
@@ -76,6 +76,15 @@
                 <listitem><para>
                     Returns the ID of the EGL frame buffer configuration
                     with respect to which the surface was created.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_GL_COLORSPACE</constant></term>
+                <listitem><para>
+                    Returns the color space used by OpenGL and OpenGL ES
+                    when rendering to the surface, either
+                    <constant>EGL_GL_COLORSPACE_SRGB</constant> or
+                    <constant>EGL_GL_COLORSPACE_LINEAR</constant>.
                 </para></listitem>
             </varlistentry>
             <varlistentry>
@@ -197,6 +206,24 @@
                 </para></listitem>
             </varlistentry>
             <varlistentry>
+                <term><constant>EGL_VG_ALPHA_FORMAT</constant></term>
+                <listitem><para>
+                    Returns the interpretation of alpha values used by
+                    OpenVG when rendering to the surface, either
+                    <constant>EGL_VG_ALPHA_FORMAT_NONPRE</constant> or
+                    <constant>EGL_VG_ALPHA_FORMAT_PRE</constant>.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><constant>EGL_VG_COLORSPACE</constant></term>
+                <listitem><para>
+                    Returns the color space used by OpenVG when rendering to
+                    the surface, either
+                    <constant>EGL_VG_COLORSPACE_sRGB</constant> or
+                    <constant>EGL_VG_COLORSPACE_LINEAR</constant>.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><constant>EGL_WIDTH</constant></term>
                 <listitem><para>
                     Returns the width of the surface in pixels.
@@ -205,6 +232,10 @@
         </variablelist>
     </refsect1>
     <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            Attribute <constant>EGL_GL_COLORSPACE</constant> is supported
+            only if the EGL version is 1.5 or greater.
+        </para>
         <para>
             Attribute <constant>EGL_MULTISAMPLE_RESOLVE</constant> is
             supported only if the EGL version is 1.4 or greater.

--- a/sdk/docs/man/eglSwapBuffers.xml
+++ b/sdk/docs/man/eglSwapBuffers.xml
@@ -47,21 +47,27 @@
     </refsect1>
     <refsect1 xml:id="description"><title>Description</title>
         <para>
-            If <parameter>surface</parameter> is a window surface,
-            <function>eglSwapBuffers</function> posts its color buffer
-            to the associated native window.
+            If <parameter>surface</parameter> is a back-buffered window
+            surface, <function>eglSwapBuffers</function> then the color
+            buffer is copied (posted) native window associated with that
+            surface. If <parameter>surface</parameter> is a single-buffered
+            window, pixmap, or pixel buffer surface,
+            <function>eglSwapBuffers</function> has no effect.
         </para>
         <para>
             The contents of ancillary buffers are always undefined after
-            calling <function>eglSwapBuffers</function>. The contents of
-            the color buffer are left unchanged if the value of the
+            calling <function>eglSwapBuffers</function>. The contents of the
+            color buffer are undefined if the value of the
             <constant>EGL_SWAP_BEHAVIOR</constant> attribute of
-            <parameter>surface</parameter> is
-            <constant>EGL_BUFFER_PRESERVED</constant>, and are undefined
-            if the value is <constant>EGL_BUFFER_DESTROYED</constant>.
-            The value of <constant>EGL_SWAP_BEHAVIOR</constant> can be
-            set for some surfaces using
+            <parameter>surface</parameter> is not
+            <constant>EGL_BUFFER_PRESERVED</constant>. The value of
+            <constant>EGL_SWAP_BEHAVIOR</constant> can be set for some
+            surfaces using
             <citerefentry><refentrytitle>eglSurfaceAttrib</refentrytitle></citerefentry>.
+            <constant>EGL_SWAP_BEHAVIOR</constant> applies only to the color
+            buffer. EGL has no way to specify or query whether or not
+            ancillary buffers are preserved, and applications should not
+            rely on this behavior.
         </para>
         <para>
             <function>eglSwapBuffers</function> performs an implicit
@@ -74,32 +80,42 @@
             <function>eglSwapBuffers</function>, but are not executed
             until the buffer exchange is completed.
         </para>
+    </refsect1>
+    <refsect1 xml:id="resize"><title>Native Window Resizing</title>
         <para>
-            If <parameter>surface</parameter> is a pixel buffer or a pixmap,
-            <function>eglSwapBuffers</function>
-            has no effect, and no error is generated.
+            If the native window corresponding to
+            <parameter>surface</parameter> has been resized prior to the
+            swap, <parameter>surface</parameter> must be resized to match.
+            <parameter>surface</parameter> will normally be resized by the
+            EGL implementation at the time the native window is resized. If
+            the implementation cannot do this transparently to the client,
+            then <function>eglSwapBuffers</function> must detect the change
+            and resize surface prior to copying its pixels to the native
+            window. If <parameter>surface</parameter> shrinks as a result of
+            resizing, some rendered pixels are lost. If
+            <parameter>surface</parameter> grows, the newly allocated buffer
+            contents are undefined. The resizing behavior described here
+            only maintains consistency of EGL surfaces and native windows;
+            clients are still responsible for detecting window size changes
+            (using platform-specific means) and changing their viewport and
+            scissor regions accordingly.
         </para>
     </refsect1>
     <refsect1 xml:id="notes"><title>Notes</title>
         <para>
-            Attribute <constant>EGL_SWAP_BEHAVIOR</constant> is
-            supported only if the EGL version is 1.2 or greater. In
-            earlier versions, behavior is as though the attribute
-            exists, and always has the value
-            <constant>EGL_BUFFER_DESTROYED</constant>.
+            Attribute <constant>EGL_SWAP_BEHAVIOR</constant> is supported
+            only if the EGL version is 1.2 or greater. In earlier versions,
+            behavior is as though the attribute exists, and always has the
+            value <constant>EGL_BUFFER_DESTROYED</constant>.
         </para>
         <para>
             The EGL 1.4 specification was updated to acknowledge that
-            ancillary buffers are not necessarily preserved after a
-            swap, and that the <constant>EGL_SWAP_BEHAVIOR</constant>
-            attribute applies only to the color buffer. This change in
-            the specification acknowledged the behavior of many shipping
+            ancillary buffers are not necessarily preserved after a swap,
+            and that the <constant>EGL_SWAP_BEHAVIOR</constant> attribute
+            applies only to the color buffer. This change in the
+            specification acknowledged the behavior of many shipping
             implementations, and is not intended to result in behavior
-            changes in any existing implementation. Applications which
-            require preservation of ancillary buffers across a swap
-            should be aware that not all implementations can preserve
-            them, and that EGL 1.4 has no way to query whether or not
-            they are preserved.
+            changes in any existing implementation.
         </para>
     </refsect1>
     <refsect1 xml:id="errors"><title>Errors</title>
@@ -127,8 +143,9 @@
     </refsect1>
     <refsect1 xml:id="seealso"><title>See Also</title>
         <para>
-            <citerefentry><refentrytitle>glFlush</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>eglCopyBuffers</refentrytitle></citerefentry>
+            <function>glFlush</function>,
+            <citerefentry><refentrytitle>eglCopyBuffers</refentrytitle></citerefentry>,
+            <function>vgFlush</function>
         </para>
     </refsect1>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>

--- a/sdk/docs/man/eglWaitSync.xml
+++ b/sdk/docs/man/eglWaitSync.xml
@@ -1,0 +1,134 @@
+<refentry xmlns="http://docbook.org/ns/docbook" version="5.0" xml:base="" xml:id="eglWaitSync">
+    <info>
+         <copyright>
+             <year>2018</year>
+             <holder>The Khronos Group Inc.</holder>
+         </copyright>
+    </info>
+    <refmeta>
+        <refentrytitle>eglWaitSync</refentrytitle>
+        <manvolnum>3G</manvolnum>
+    </refmeta>
+    <refnamediv>
+        <refname>eglWaitSync</refname>
+        <refpurpose>
+            Wait in the server for a sync object to be signalled
+        </refpurpose>
+    </refnamediv>
+    <refsynopsisdiv>
+        <title>C Specification</title>
+        <funcsynopsis>
+            <funcprototype>
+            <funcdef>EGLBoolean <function>eglWaitSync</function></funcdef>
+            <paramdef>(EGLDisplay <parameter>display</parameter></paramdef>
+            <paramdef>EGLSync <parameter>sync</parameter></paramdef>
+            <paramdef>EGLint <parameter>flags</parameter></paramdef>
+            </funcprototype>
+        </funcsynopsis>
+    </refsynopsisdiv>
+    <refsect1 xml:id="parameters"><title>Parameters</title>
+        <variablelist>
+            <varlistentry>
+                <term><parameter>display</parameter></term>
+                <listitem><para>
+                    Specifies the <acronym>EGL</acronym> display connection.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>sync</parameter></term>
+                <listitem><para>
+                    Specifies the sync object to wait on.
+                </para></listitem>
+            </varlistentry>
+            <varlistentry>
+                <term><parameter>flags</parameter></term>
+                <listitem><para>
+                    Specifies flags controlling wait behavior.
+                </para></listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+    <refsect1 xml:id="description"><title>Description</title>
+        <para>
+            <function>eglWaitSync</function> is similar to
+            <function>eglClientWaitSync</function>, but instead of blocking
+            and not returning to the application until
+            <parameter>sync</parameter> is signaled,
+            <function>eglWaitSync</function> returns immediately. On
+            success, <constant>EGL_TRUE</constant> is returned, and the
+            server for the client API context will block until
+            <parameter>sync</parameter> is signaled.
+        </para>
+        <para>
+            Note: <function>eglWaitSync</function> allows applications to
+            continue to queue commands from the application in anticipation
+            of the sync being signaled, potentially increasing parallelism
+            between application, client API server code, and the GPU. The
+            server only blocks execution of commands for the specific
+            context on which <function>eglWaitSync</function> was issued;
+            other contexts implemented by the same server are not affected..
+        </para>
+        <para>
+            <parameter>sync</parameter> has the same meaning as for
+            <function>eglClientWaitSync</function>.
+        </para>
+        <para>
+            <parameter>flags</parameter> must be 0.
+        </para>
+        <para>
+            <function>eglWaitSync</function> requires support from the bound
+            client API, and will not succeed unless the same client API
+            properties described for creation of fence syncs in
+            <citerefentry><refentrytitle>eglCreateSync</refentrytitle></citerefentry>
+            are satisfied.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="errors"><title>Errors</title>
+        <para>
+            <function>eglWaitSync</function> returns
+            <constant>EGL_FALSE</constant> on failure, and does not cause
+            the server for the client API context to block.
+        </para>
+        <para>
+            If the current context for the currently bound client API does
+            not support server waits, an <constant>EGL_BAD_MATCH</constant>
+            error is generated.
+        </para>
+        <para>
+            If no context is current for the currently bound client API
+            (i.e., <function>eglGetCurrentContext</function> returns
+            <constant>EGL_NO_CONTEXT</constant>), an
+            <constant>EGL_BAD_MATCH</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>display</parameter> does not match the
+            <type>EGLDisplay</type> passed to
+            <function>eglCreateSync</function> when
+            <parameter>sync</parameter> was created, the behavior is
+            undefined.
+        </para>
+        <para>
+            If <parameter>sync</parameter> is not a valid sync object for
+            <parameter>display</parameter>, an
+            <constant>EGL_BAD_PARAMETER</constant> error is generated.
+        </para>
+        <para>
+            If <parameter>flags</parameter> is not 0, an
+            <constant>EGL_BAD_PARAMETER</constant> error is generated.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="notes"><title>Notes</title>
+        <para>
+            <function>eglWaitSync</function> is available only if the EGL
+            version is 1.5 or greater.
+        </para>
+    </refsect1>
+    <refsect1 xml:id="seealso"><title>See Also</title>
+        <para>
+            <citerefentry><refentrytitle>eglClientWaitSync</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglCreateSync</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>eglGetCurrentContext</refentrytitle></citerefentry>
+        </para>
+    </refsect1>
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="copyright.xml"/>
+</refentry>

--- a/sdk/docs/man/html/Makefile
+++ b/sdk/docs/man/html/Makefile
@@ -16,14 +16,19 @@ EGLXML = \
     eglBindAPI.xhtml \
     eglBindTexImage.xhtml \
     eglChooseConfig.xhtml \
+    eglClientWaitSync.xhtml \
     eglCopyBuffers.xhtml \
     eglCreateContext.xhtml \
+    eglCreateImage.xhtml \
     eglCreatePbufferSurface.xhtml \
     eglCreatePbufferFromClientBuffer.xhtml \
     eglCreatePixmapSurface.xhtml \
+    eglCreateSync.xhtml \
     eglCreateWindowSurface.xhtml \
     eglDestroyContext.xhtml \
+    eglDestroyImage.xhtml \
     eglDestroySurface.xhtml \
+    eglDestroySync.xhtml \
     eglGetConfigAttrib.xhtml \
     eglGetConfigs.xhtml \
     eglGetCurrentContext.xhtml \
@@ -31,7 +36,9 @@ EGLXML = \
     eglGetCurrentSurface.xhtml \
     eglGetDisplay.xhtml \
     eglGetError.xhtml \
+    eglGetPlatformDisplay.xhtml \
     eglGetProcAddress.xhtml \
+    eglGetSyncAttrib.xhtml \
     eglInitialize.xhtml \
     eglIntro.xhtml \
     eglMakeCurrent.xhtml \
@@ -47,7 +54,8 @@ EGLXML = \
     eglTerminate.xhtml \
     eglWaitClient.xhtml \
     eglWaitGL.xhtml \
-    eglWaitNative.xhtml
+    eglWaitNative.xhtml \
+    eglWaitSync.xhtml
 
 XML    = $(EGLXML)
 

--- a/sdk/docs/man/html/Makefile
+++ b/sdk/docs/man/html/Makefile
@@ -23,6 +23,7 @@ EGLXML = \
     eglCreatePbufferSurface.xhtml \
     eglCreatePbufferFromClientBuffer.xhtml \
     eglCreatePixmapSurface.xhtml \
+    eglCreatePlatformPixmapSurface.xhtml \
     eglCreatePlatformWindowSurface.xhtml \
     eglCreateSync.xhtml \
     eglCreateWindowSurface.xhtml \

--- a/sdk/docs/man/html/Makefile
+++ b/sdk/docs/man/html/Makefile
@@ -23,6 +23,7 @@ EGLXML = \
     eglCreatePbufferSurface.xhtml \
     eglCreatePbufferFromClientBuffer.xhtml \
     eglCreatePixmapSurface.xhtml \
+    eglCreatePlatformWindowSurface.xhtml \
     eglCreateSync.xhtml \
     eglCreateWindowSurface.xhtml \
     eglDestroyContext.xhtml \

--- a/sdk/docs/man/html/eglBindAPI.xhtml
+++ b/sdk/docs/man/html/eglBindAPI.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglBindAPI - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -62,6 +62,7 @@
             <code class="function">eglGetCurrentDisplay</code>,
             <code class="function">eglGetCurrentSurface</code>,
             <code class="function">eglMakeCurrent</code>,
+            <code class="function">eglSwapInterval</code>,
             <code class="function">eglWaitClient</code>, and
             <code class="function">eglWaitNative</code>.
         </p>
@@ -130,6 +131,7 @@
             <a class="citerefentry" href="eglGetCurrentSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetCurrentSurface</span></span></a>,
             <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>,
             <a class="citerefentry" href="eglQueryAPI.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryAPI</span></span></a>,
+            <a class="citerefentry" href="eglSwapInterval.xhtml"><span class="citerefentry"><span class="refentrytitle">eglSwapInterval</span></span></a>,
             <a class="citerefentry" href="eglWaitClient.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitClient</span></span></a>,
             <a class="citerefentry" href="eglWaitNative.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitNative</span></span></a>
         </p>

--- a/sdk/docs/man/html/eglBindTexImage.xhtml
+++ b/sdk/docs/man/html/eglBindTexImage.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglBindTexImage - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglChooseConfig.xhtml
+++ b/sdk/docs/man/html/eglChooseConfig.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglChooseConfig - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -514,8 +514,9 @@
                     The default value is zero.
                 </p>
               <p>
-                    Most imlementations do not support overlay or
-                    underlay planes (buffer levels other than zero).
+                    Most platforms do not support buffer levels other than
+                    zero. The behavior of windows placed in overlay and
+                    underlay planes depends on the underlying platform.
                 </p>
             </dd>
             <dt>

--- a/sdk/docs/man/html/eglChooseConfig.xhtml
+++ b/sdk/docs/man/html/eglChooseConfig.xhtml
@@ -189,8 +189,7 @@
                     is zero.
                 </p>
               <p>
-                    The alpha mask buffer is used only by OpenGL and
-                    OpenGL ES client APIs.
+                    The alpha mask buffer is used only by OpenVG.
                 </p>
             </dd>
             <dt>

--- a/sdk/docs/man/html/eglClientWaitSync.xhtml
+++ b/sdk/docs/man/html/eglClientWaitSync.xhtml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglClientWaitSync - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglClientWaitSync">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglClientWaitSync — 
+            Wait in the client for a sync object to be signalled
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLint <strong class="fsfunc">eglClientWaitSync</strong>(</code>
+              </td>
+              <td>(EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLSync <var class="pdparam">sync</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLint <var class="pdparam">flags</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLTime <var class="pdparam">timeout</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the <abbr class="acronym">EGL</abbr> display connection.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>sync</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the sync object to wait on.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>flags</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies flags controlling wait behavior.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>timeout</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies wait timeout interval.
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglClientWaitSync</code> blocks the calling thread
+            until the specified sync object <em class="parameter"><code>sync</code></em> is
+            signaled, or until <em class="parameter"><code>timeout</code></em> nanoseconds
+            have passed.
+        </p>
+        <p>
+            More than one <code class="function">eglClientWaitSync</code> may be
+            outstanding on the same <em class="parameter"><code>sync</code></em> at any given
+            time. When there are multiple threads blocked on the same
+            <em class="parameter"><code>sync</code></em> and the sync object is signaled, all
+            such threads are released, but the order in which they are
+            released is not defined.
+        </p>
+        <p>
+            If the value of <em class="parameter"><code>timeout</code></em> is zero, then
+            <code class="function">eglClientWaitSync</code> simply tests the current
+            status of <em class="parameter"><code>sync</code></em>. If the value of
+            <em class="parameter"><code>timeout</code></em> is the special value
+            <code class="constant">EGL_FOREVER</code>, then
+            <code class="function">eglClientWaitSync</code> does not time out. For
+            all other values, <em class="parameter"><code>timeout</code></em> is adjusted to
+            the closest value allowed by the implementation-dependent
+            timeout accuracy, which may be substantially longer than one
+            nanosecond.
+        </p>
+        <p>
+            <code class="function">eglClientWaitSync</code> returns one of three
+            status values describing the reason for returning. A return
+            value of <code class="constant">EGL_TIMEOUT_EXPIRED</code> indicates that
+            the specified timeout period expired before
+            <em class="parameter"><code>sync</code></em> was signaled, or if
+            <em class="parameter"><code>timeout</code></em> is zero, indicates that
+            <em class="parameter"><code>sync</code></em> is not signaled. A return value of
+            <code class="constant">EGL_CONDITION_SATISFIED</code> indicates that
+            <em class="parameter"><code>sync</code></em> was signaled before the timeout
+            expired, which includes the case when
+            <em class="parameter"><code>sync</code></em> was already signaled when
+            <code class="function">eglClientWaitSync</code> was called. If an error
+            occurs then an error is generated and
+            <code class="constant">EGL_FALSE</code> is returned.
+        </p>
+        <p>
+            If the sync object being blocked upon will not be signaled in
+            finite time (for example, by an associated fence command issued
+            previously, but not yet flushed to the graphics pipeline), then
+            <code class="function">eglClientWaitSync</code> may wait forever. To help
+            prevent this behavior, if the
+            <code class="constant">EGL_SYNC_FLUSH_COMMANDS_BIT</code> bit is set in
+            <em class="parameter"><code>flags</code></em>, and <em class="parameter"><code>sync</code></em> is
+            unsignaled when <code class="function">eglClientWaitSync</code> is
+            called, then the equivalent of Flush() will be performed for the
+            current API context (i.e., the context returned by
+            <code class="function">eglGetCurrentContext</code>) before blocking on
+            <em class="parameter"><code>sync</code></em>. If no context is current for the
+            bound API, the <code class="constant">EGL_SYNC_FLUSH_COMMANDS_BIT</code>
+            bit is ignored.
+        </p>
+        <p>
+            Note: the simple Flush behavior defined by
+            <code class="constant">EGL_SYNC_FLUSH_COMMANDS_BIT</code> will not help
+            when waiting for a fence command issued in a different context's
+            command stream. Applications which block on a fence sync object
+            must take additional steps to ensure that the context from which
+            the associated fence command was issued has flushed that command
+            to the graphics pipeline.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            <code class="function">eglClientWaitSync</code> returns
+            <code class="constant">EGL_FALSE</code> on failure.
+        </p>
+        <p>
+            If <em class="parameter"><code>sync</code></em> is not a valid sync object for
+            <em class="parameter"><code>display</code></em>, an
+            <code class="constant">EGL_BAD_PARAMETER</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>display</code></em> does not match the
+            <span class="type">EGLDisplay</span> passed to
+            <code class="function">eglCreateSync</code> when
+            <em class="parameter"><code>sync</code></em> was created, the behaviour is
+            undefined.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            <code class="function">eglClientWaitSync</code> is available only if the
+            EGL version is 1.5 or greater.
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglCreateSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateSync</span></span></a>,
+            <a class="citerefentry" href="eglGetCurrentContext.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetCurrentContext</span></span></a>,
+            <a class="citerefentry" href="eglWaitSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitSync</span></span></a>,
+            <code class="function">glFinish</code>,
+            <code class="function">vgFinish</code>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglCopyBuffers.xhtml
+++ b/sdk/docs/man/html/eglCopyBuffers.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCopyBuffers - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglCreateContext.xhtml
+++ b/sdk/docs/man/html/eglCreateContext.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreateContext - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -144,137 +144,143 @@
           <dl class="variablelist">
             <dt>
               <span class="term">
-                <code class="constant">EGL_CONTEXT_CLIENT_VERSION</code>
+                <code class="constant">EGL_CONTEXT_MAJOR_VERSION</code>
               </span>
             </dt>
             <dd>
               <p>
-                    Must be followed by an integer that determines which
-                    version of an OpenGL ES context to create. A value
-                    of 1 specifies creation of an OpenGL ES 1.x context.
-                    An attribute value of 2 specifies creation of an
-                    OpenGL ES 2.x context. The default value is 1. This
-                    attribute can only be specified when creating a
-                    OpenGL ES context (e.g. when the current rendering
-                    API is <code class="constant">EGL_OPENGL_ES_API</code>).
+                    Must be followed by an integer specifying the requested
+                    major version of an OpenGL or OpenGL ES context. The
+                    default value is 1. This attribute is an alias of the
+                    older <code class="constant">EGL_CONTEXT_CLIENT_VERSION</code>,
+                    and the tokens may be used interchangeably.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_CONTEXT_MINOR_VERSION</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Must be followed by an integer specifying the requested
+                    minor version of an OpenGL or OpenGL ES context. The
+                    default value is 0.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_CONTEXT_OPENGL_PROFILE_MASK</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Must be followed by an integer bitmask specifying the
+                    <em class="firstterm">profile</em> of an OpenGL context.
+                    Bits which may be set include
+                    <code class="constant">EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT</code>
+                    for a core profile and
+                    <code class="constant">EGL_CONTEXT_OPENGL_COMPATIBILITY_PROFILE_BIT</code>
+                    for a compatibility profile. The default value is
+                    <code class="constant">EGL_CONTEXT_OPENGL_CORE_PROFILE_BIT</code>.
+                    All OpenGL 3.2 and later implementations are required to
+                    implement the core profile, but implementation of the
+                    compatibility profile is optional.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_CONTEXT_OPENGL_DEBUG</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Must be followed by <code class="constant">EGL_TRUE</code>,
+                    specifying that an OpenGL or OpenGL ES <em class="firstterm">debug
+                    context</em> should be created, or
+                    <code class="constant">EGL_FALSE</code>, if a non-debug context
+                    should be created. The default value is
+                    <code class="constant">EGL_FALSE</code>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_CONTEXT_OPENGL_FORWARD_COMPATIBLE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Must be followed by <code class="constant">EGL_TRUE</code>,
+                    specifying that a
+                    <em class="firstterm">forward-compatible</em> OpenGL context
+                    should be created, or <code class="constant">EGL_FALSE</code>, if
+                    a non-forward-compatible context should be created. The
+                    default value is <code class="constant">EGL_FALSE</code>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_CONTEXT_OPENGL_ROBUST_ACCESS</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Must be followed by <code class="constant">EGL_TRUE</code>,
+                    specifying that an OpenGL or OpenGL ES context
+                    supporting <em class="firstterm">robust buffer access</em>
+                    should be created, or <code class="constant">EGL_FALSE</code>, if
+                    a non-robust context should be created. The default
+                    value is <code class="constant">EGL_FALSE</code>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Must be followed by
+                    <code class="constant">EGL_LOSE_CONTEXT_ON_RESET</code>,
+                    specifying that an OpenGL or OpenGL ES context with
+                    reset notification behavior
+                    <code class="constant">GL_LOSE_CONTEXT_ON_RESET_ARB</code> should
+                    be created, or
+                    <code class="constant">EGL_NO_RESET_NOTIFICATION</code>,
+                    specifying that an OpenGL or OpenGL ES context with
+                    reset notification behavior
+                    <code class="constant">GL_NO_RESET_NOTIFICATION_ARB</code> should
+                    be created, as described by the
+                    <code class="constant">GL_ARB_robustness</code> extension.
+                </p>
+              <p>
+                    If the
+                    <code class="constant">EGL_CONTEXT_OPENGL_ROBUST_ACCESS</code>
+                    attribute is not set to <code class="constant">EGL_TRUE</code>,
+                    context creation will not fail, but the resulting
+                    context may not support robust buffer access, and
+                    therefore may not support the requested reset
+                    notification strategy The default value for
+                    <code class="constant">EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY</code>
+                    is <code class="constant">EGL_NO_RESET_NOTIFICATION</code> .
                 </p>
             </dd>
           </dl>
         </div>
-      </div>
-      <div class="refsect1" id="notes">
-        <h2>Notes</h2>
         <p>
-            The current rendering API is only respected if the EGL
-            version is 1.2 or greater. Otherwise, an OpenGL ES context
-            will always be created.
-        </p>
-        <p>
-            The <code class="constant">EGL_CONTEXT_CLIENT_VERSION</code>
-            attribute is only supported if the EGL version is 1.3 or
-            greater.
-        </p>
-        <p>
-            A <em class="firstterm">process</em> is a single execution environment,
-            implemented in a single address space, consisting of one or more threads.
-        </p>
-        <p>
-            A <em class="firstterm">thread</em> is one of a set of subprocesses that
-            share a single address space, but maintain separate program counters,
-            stack spaces, and other related global data.
-            A thread is the only member of its subprocess group is equivalent to a
-            process.
+            There are many possible interactions between requested OpenGL
+            and OpenGL ES context creation attributes, depending on the API
+            versions and extensions supported by the implementation. These
+            interactions are described in detail in the EGL 1.5
+            Specification, but are not listed here for compactness. The
+            requested attributes may not be able to be satisfied, but
+            context creation may still succeed. Applications should ensure
+            that the OpenGL or OpenGL ES contexts supports needed features
+            before using them, by determining the actual context version,
+            supported extensions, and supported context flags using runtime
+            queries.
         </p>
       </div>
-      <div class="refsect1" id="errors">
-        <h2>Errors</h2>
-        <p>
-            <code class="constant">EGL_NO_CONTEXT</code> is returned if creation of
-            the context fails.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_MATCH</code> is generated if the
-            current rendering API is <code class="constant">EGL_NONE</code> (this
-            can only arise in an EGL implementation which does not
-            support OpenGL ES, prior to the first call to
-            <code class="function">eglBindAPI</code>).
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_MATCH</code> is generated if the
-            server context state for
-            <em class="parameter"><code>share_context</code></em> exists in an address
-            space which cannot be shared with the newly created context,
-            if <em class="parameter"><code>share_context</code></em> was created on a
-            different display than the one referenced by
-            <em class="parameter"><code>config</code></em>, or if the contexts are
-            otherwise incompatible.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_DISPLAY</code> is generated if
-            <em class="parameter"><code>display</code></em> is not an EGL display connection.
-        </p>
-        <p>
-            <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
-            <em class="parameter"><code>display</code></em> has not been initialized.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_CONFIG</code> is generated if
-            <em class="parameter"><code>config</code></em> is not an EGL frame buffer
-            configuration, or does not support the current rendering
-            API. This includes requesting creation of an OpenGL ES 1.x
-            context when the <code class="constant">EGL_RENDERABLE_TYPE</code>
-            attribute of <em class="parameter"><code>config</code></em> does not contain
-            <code class="constant">EGL_OPENGL_ES_BIT</code>, or creation of an
-            OpenGL ES 2.x context when the attribute does not contain
-            <code class="constant">EGL_OPENGL_ES2_BIT</code>.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_CONTEXT</code> is generated if
-            <em class="parameter"><code>share_context</code></em> is not an EGL rendering
-            context of the same client API type as the newly created
-            context and is not <code class="constant">EGL_NO_CONTEXT</code>.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_ATTRIBUTE</code> is generated if
-            <em class="parameter"><code>attrib_list</code></em> contains an invalid
-            context attribute or if an attribute is not recognized or
-            out of range. Note that attribute
-            <code class="constant">EGL_CONTEXT_CLIENT_VERSION</code> is
-            only valid when the current rendering API is
-            <code class="constant">EGL_OPENGL_ES_API</code>.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_ALLOC</code> is generated if there are not
-            enough resources to allocate the new context.
-        </p>
-      </div>
-      <div class="refsect1" id="seealso">
-        <h2>See Also</h2>
-        <p>
-            <a class="citerefentry" href="eglDestroyContext.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroyContext</span></span></a>,
-            <a class="citerefentry" href="eglChooseConfig.xhtml"><span class="citerefentry"><span class="refentrytitle">eglChooseConfig</span></span></a>,
-            <a class="citerefentry" href="eglGetConfigs.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetConfigs</span></span></a>,
-            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>
-        </p>
-      </div>
-      <p>
-    </p>
-      <div class="refsect3" id="copyright">
-        <img src="KhronosLogo.jpg"/>
-        <p>
-            Copyright © 2003-2014 The Khronos Group Inc.
-            Permission is hereby granted, free of charge, to any person obtaining a
-            copy of this software and/or associated documentation files (the
-            "Materials"), to deal in the Materials without restriction, including
-            without limitation the rights to use, copy, modify, merge, publish,
-            distribute, sublicense, and/or sell copies of the Materials, and to
-            permit persons to whom the Materials are furnished to do so, subject to
-            the condition that this copyright notice and permission notice shall be included
-            in all copies or substantial portions of the Materials.
-        </p>
-      </div>
-      <p>
-</p>
     </div>
     <footer/>
   </body>

--- a/sdk/docs/man/html/eglCreateImage.xhtml
+++ b/sdk/docs/man/html/eglCreateImage.xhtml
@@ -107,7 +107,7 @@
             </dt>
             <dd>
               <p>
-                    Specifies attributes used to select sub-sectins of the
+                    Specifies attributes used to select sub-sections of the
                     resource to be used as the image source.
                 </p>
             </dd>

--- a/sdk/docs/man/html/eglCreateImage.xhtml
+++ b/sdk/docs/man/html/eglCreateImage.xhtml
@@ -64,7 +64,7 @@
             <dt>
               <span class="term">
                 <em class="parameter">
-                  <code>sync</code>
+                  <code>context</code>
                 </em>
               </span>
             </dt>

--- a/sdk/docs/man/html/eglCreateImage.xhtml
+++ b/sdk/docs/man/html/eglCreateImage.xhtml
@@ -1,0 +1,774 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreateImage - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglCreateImage">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglCreateImage — 
+            Create a new <span class="type">EGLImage</span> object
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLImage <strong class="fsfunc">eglCreateImage</strong>(</code>
+              </td>
+              <td>(EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLContext <var class="pdparam">context</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLenum <var class="pdparam">target</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLClientBuffer <var class="pdparam">buffer</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>const EGLAttrib *<var class="pdparam">attrib_list</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the <abbr class="acronym">EGL</abbr> display connection.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>sync</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the client API context for which the image is
+                    created.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>target</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the type of resource used as the image source.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>buffer</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the resource to be used as the image source.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>attrib_list</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies attributes used to select sub-sectins of the
+                    resource to be used as the image source.
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglCreateImage</code> is used to create an
+            <span class="type">EGLImage</span> object from an existing image resource
+            <em class="parameter"><code>buffer</code></em>. <em class="parameter"><code>display</code></em>
+            specifies the EGL display used for this operation.
+            <em class="parameter"><code>context</code></em> specifies the EGL client API
+            context used for this operation, or
+            <code class="constant">EGL_NO_CONTEXT</code> if a client API context is
+            not required. <em class="parameter"><code>target</code></em> specifies the type
+            of resource being used as the <span class="type">EGLImage</span> source
+            (examples include two-dimensional textures in OpenGL ES contexts
+            and <span class="type">VGImage</span> objects in OpenVG contexts).
+            <em class="parameter"><code>buffer</code></em> is the name (or handle) of a
+            resource to be used as the <span class="type">EGLImage</span> source, cast
+            into the type <span class="type">EGLClientBuffer</span>.
+            <em class="parameter"><code>attrib_list</code></em> is a list of attribute-value
+            pairs which is used to select sub-sections of
+            <em class="parameter"><code>buffer</code></em> for use as the
+            <span class="type">EGLImage</span> source, such as mipmap levels for OpenGL
+            ES texture map resources, as well as behavioral options, such as
+            whether to preserve pixel data during creation. If
+            <em class="parameter"><code>attrib_list</code></em> is
+            non-<code class="constant">NULL</code>, the last attribute specified in
+            the list must be <code class="constant">EGL_NONE</code>.
+        </p>
+        <p>
+            The resource specified by <em class="parameter"><code>display</code></em>,
+            <em class="parameter"><code>context</code></em>, <em class="parameter"><code>target</code></em>,
+            <em class="parameter"><code>buffer</code></em>, and
+            <em class="parameter"><code>attrib_list</code></em> must not itself be an
+            <span class="type">EGLImage</span> sibling, or bound to a pbuffer
+            <span class="type">EGLSurface</span> resource
+            (<code class="function">eglBindTexImage</code>,
+            <code class="function">eglCreatePbufferFromClientBuffer</code>).
+        </p>
+        <p>
+            Values accepted for <em class="parameter"><code>target</code></em> are shown in
+            table <a class="xref" href="#tab-imagetarget" title="Table 1.  Legal values for eglCreateImage target">Table 1, “
+                Legal values for <code class="function">eglCreateImage</code> <em class="parameter"><code>target</code></em>
+            ”</a>.
+        </p>
+        <div class="table" id="tab-imagetarget">
+          <div class="table-title">Table 1. 
+                Legal values for <code class="function">eglCreateImage</code> <em class="parameter"><code>target</code></em>
+            </div>
+          <div class="table-contents">
+            <table style="border-collapse: collapse; border-top: 2px solid ; border-bottom: 2px solid ; border-left: 2px solid ; border-right: 2px solid ; ">
+              <colgroup>
+                <col/>
+                <col/>
+              </colgroup>
+              <thead>
+                <tr>
+                  <th style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <em class="parameter">
+                      <code>target</code>
+                    </em>
+                  </th>
+                  <th style="text-align: left; border-bottom: 2px solid ; ">Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_2D</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for GL 2D texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for the +X face of GL cubemap texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for the -X face of GL cubemap texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for the +Y face of GL cubemap texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for the -Y face of GL cubemap texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for the +Z face of GL cubemap texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for the -Z face of GL cubemap texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_3D</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Used for OpenGL and OpenGL ES 3D texture images</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; ">
+                    <code class="constant">EGL_GL_RENDERBUFFER</code>
+                  </td>
+                  <td style="text-align: left; ">Used for OpenGL and OpenGL ES renderbuffer images</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <br class="table-break"/>
+        <p>
+            Attribute names accepted in <em class="parameter"><code>attrib_list</code></em>
+            are shown in table <a class="xref" href="#tab-imageattr" title="Table 2.  Legal attributes for eglCreateImage attrib_list parameter">Table 2, “
+                Legal attributes for <code class="function">eglCreateImage</code>
+                <em class="parameter"><code>attrib_list</code></em> parameter
+            ”</a>, together
+            with the <em class="parameter"><code>target</code></em> for which each attribute
+            name is valid, and the default value used for each attribute if
+            it is not included in <em class="parameter"><code>attrib_list</code></em>.
+        </p>
+        <div class="table" id="tab-imageattr">
+          <div class="table-title">Table 2. 
+                Legal attributes for <code class="function">eglCreateImage</code>
+                <em class="parameter"><code>attrib_list</code></em> parameter
+            </div>
+          <div class="table-contents">
+            <table style="border-collapse: collapse; border-top: 2px solid ; border-bottom: 2px solid ; border-left: 2px solid ; border-right: 2px solid ; ">
+              <colgroup>
+                <col/>
+                <col/>
+                <col/>
+                <col/>
+              </colgroup>
+              <thead>
+                <tr>
+                  <th style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <em class="parameter">
+                      <code>target</code>
+                    </em>
+                  </th>
+                  <th style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Notes</th>
+                  <td style="border-right: 2px solid ; border-bottom: 2px solid ; " class="auto-generated"> </td>
+                  <td style="border-bottom: 2px solid ; " class="auto-generated"> </td>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Attribute</td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Description</td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Valid <em class="parameter"><code>target</code></em>s</td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Default Value</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_NONE</code>
+                  </td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Marks the end of the attribute-value list</td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">All</td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">N/A</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_LEVEL</code>
+                  </td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                            Specifies the mipmap level used as the
+                            <span class="type">EGLImage</span> source. Must be part of
+                            the complete texture object
+                            <em class="parameter"><code>buffer</code></em>
+                        </td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+                            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code>, or
+                            <code class="constant">EGL_GL_TEXTURE_3D</code>
+                        </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">0</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_ZOFFSET</code>
+                  </td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                            Specifies the depth offset of the image to use
+                            as the <span class="type">EGLImage</span> source. Must be
+                            part of the complete texture object
+                            <em class="parameter"><code>buffer</code></em>
+                        </td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_GL_TEXTURE_3D</code>
+                  </td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">0</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; ">
+                    <code class="constant">EGL_IMAGE_PRESERVED</code>
+                  </td>
+                  <td style="text-align: left; border-right: 2px solid ; ">Whether to preserve pixel data</td>
+                  <td style="text-align: left; border-right: 2px solid ; ">All</td>
+                  <td style="text-align: left; ">
+                    <code class="constant">EGL_FALSE</code>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <br class="table-break"/>
+        <p>
+            <code class="function">eglCreateImage</code> returns an
+            <span class="type">EGLImage</span> object corresponding to the image data
+            specified by <em class="parameter"><code>display</code></em>,
+            <em class="parameter"><code>context</code></em>, <em class="parameter"><code>target</code></em>,
+            <em class="parameter"><code>buffer</code></em> and
+            <em class="parameter"><code>attrib_list</code></em> which may be referenced by
+            client API operations.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_3D</code>,
+            <code class="constant">EGL_GL_RENDERBUFFER</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_X</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_X</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Y</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Y</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_POSITIVE_Z</code>, or
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_NEGATIVE_Z</code>,
+            <em class="parameter"><code>display</code></em> must be a valid
+            <span class="type">EGLDisplay</span>, and <em class="parameter"><code>context</code></em> must
+            be a valid OpenGL or OpenGL ES API context on that display.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <em class="parameter"><code>buffer</code></em> must be the name of a nonzero,
+            <code class="constant">GL_TEXTURE_2D</code> target texture object, cast
+            into the type <span class="type">EGLClientBuffer</span>.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is one of the
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code> enumerants,
+            <em class="parameter"><code>buffer</code></em> must be the name of a nonzero,
+            <code class="constant">GL_TEXTURE_CUBE_MAP</code> (or equivalent in GL
+            extensions) target texture object, cast into the type
+            <span class="type">EGLClientBuffer</span>.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_3D</code>,
+            <em class="parameter"><code>buffer</code></em> must be the name of a nonzero,
+            <code class="constant">GL_TEXTURE_3D</code> (or equivalent in GL
+            extensions) target texture object, cast into the type
+            <span class="type">EGLClientBuffer</span>.
+        </p>
+        <p>
+            <em class="parameter"><code>attrib_list</code></em> should specify the mipmap
+            level (<code class="constant">EGL_GL_TEXTURE_LEVEL</code>) and, where
+            applicable, z-offset
+            (<code class="constant">EGL_GL_TEXTURE_ZOFFSET</code>) which will be used
+            as the <span class="type">EGLImage</span> source; If not specified, the
+            default values listed in table <a class="xref" href="#tab-imageattr" title="Table 2.  Legal attributes for eglCreateImage attrib_list parameter">Table 2, “
+                Legal attributes for <code class="function">eglCreateImage</code>
+                <em class="parameter"><code>attrib_list</code></em> parameter
+            ”</a>
+            will be used instead. Additional values specified in are
+            ignored.
+        </p>
+        <p>
+            There must exist some levels <span class="emphasis"><em>x</em></span> and
+            <span class="emphasis"><em>y</em></span> such that the mipmap level requested lies
+            between <span class="emphasis"><em>x</em></span> and <span class="emphasis"><em>y</em></span>
+            (inclusive), the texture would be mipmap complete were
+            <span class="emphasis"><em>x</em></span> substituted for the base level and
+            <span class="emphasis"><em>y</em></span> substituted for the max level, and all
+            levels less than <span class="emphasis"><em>x</em></span> or greater than
+            <span class="emphasis"><em>y</em></span> are unspecified. For cubemaps a single
+            pair <span class="emphasis"><em>x</em></span> and <span class="emphasis"><em>y</em></span> must
+            apply to all faces. For three-dimensional textures, the
+            specified z-offset must be smaller than the depth of the
+            specified mipmap level.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_RENDERBUFFER</code>,
+            <em class="parameter"><code>buffer</code></em> must be the name of a complete,
+            nonzero, non-multisampled <code class="constant">GL_RENDERBUFFER</code>
+            (or equivalent in extensions) target object, cast into the type
+            <span class="type">EGLClientBuffer</span>. Values specified in
+            <em class="parameter"><code>attrib_list</code></em> are ignored.
+        </p>
+        <p>
+            If the value of attribute
+            <code class="constant">EGL_IMAGE_PRESERVED</code> is
+            <code class="constant">EGL_FALSE</code> (the default), then all pixel
+            data values associated with <em class="parameter"><code>buffer</code></em> will
+            be undefined after <code class="function">eglCreateImage</code> returns.
+        </p>
+        <p>
+            If the value of attribute
+            <code class="constant">EGL_IMAGE_PRESERVED</code> is
+            <code class="constant">EGL_TRUE</code>, then all pixel data values
+            associated with <em class="parameter"><code>buffer</code></em> are preserved.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            <code class="function">eglCreateImage</code> returns
+            <code class="constant">EGL_NO_IMAGE</code> on failure. The contents of
+            <em class="parameter"><code>buffer</code></em> will be unaffected.
+        </p>
+        <p>
+            If <em class="parameter"><code>display</code></em> is not the handle of a valid
+            <span class="type">EGLDisplay</span> object, the error
+            <code class="constant">EGL_BAD_DISPLAY</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>context</code></em> is neither the handle of a
+            valid <span class="type">EGLContext</span> object on
+            <em class="parameter"><code>display</code></em> nor
+            <code class="constant">EGL_NO_CONTEXT</code>, the error
+            <code class="constant">EGL_BAD_CONTEXT</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is not one of the values in
+            table <a class="xref" href="#tab-imagetarget" title="Table 1.  Legal values for eglCreateImage target">Table 1, “
+                Legal values for <code class="function">eglCreateImage</code> <em class="parameter"><code>target</code></em>
+            ”</a>, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code>,
+            <code class="constant">EGL_GL_RENDERBUFFER</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code>, and
+            <em class="parameter"><code>display</code></em> is not a valid
+            <span class="type">EGLDisplay</span>, the error
+            <code class="constant">EGL_BAD_DISPLAY</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code>,
+            <code class="constant">EGL_GL_RENDERBUFFER</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code>, and
+            <em class="parameter"><code>context</code></em> is not a valid
+            <span class="type">EGLContext</span>, the error
+            <code class="constant">EGL_BAD_CONTEXT</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code>,
+            <code class="constant">EGL_GL_RENDERBUFFER</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code>, and
+            <em class="parameter"><code>context</code></em> is not a valid GL context, or
+            does not match the <em class="parameter"><code>display</code></em>, the error
+            <code class="constant">EGL_BAD_MATCH</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code> and
+            <em class="parameter"><code>buffer</code></em> is not the name of a texture
+            object of type <em class="parameter"><code>target</code></em>, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_RENDERBUFFER</code> and
+            <em class="parameter"><code>buffer</code></em> is not the name of a renderbuffer
+            object, or if <em class="parameter"><code>buffer</code></em> is the name of a
+            multisampled renderbuffer object, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
+        </p>
+        <p>
+            If <code class="constant">EGL_GL_TEXTURE_LEVEL</code> is nonzero,
+            <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code>, and
+            <em class="parameter"><code>buffer</code></em> is not the name of a complete GL
+            texture object, the error <code class="constant">EGL_BAD_PARAMETER</code>
+            is generated.
+        </p>
+        <p>
+            If <code class="constant">EGL_GL_TEXTURE_LEVEL</code> is 0,
+            <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code>,
+            <em class="parameter"><code>buffer</code></em> is the name of an incomplete GL
+            texture object, and any mipmap levels other than mipmap level 0
+            are specified, the error <code class="constant">EGL_BAD_PARAMETER</code>
+            is generated.
+        </p>
+        <p>
+            If <code class="constant">EGL_GL_TEXTURE_LEVEL</code> is 0,
+            <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code>,
+            <em class="parameter"><code>buffer</code></em> is not the name of a complete GL
+            texture object, and mipmap level 0 is not specified, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
+        </p>
+        <p>
+            If <code class="constant">EGL_GL_TEXTURE_LEVEL</code> is 0,
+            <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code>,
+            <em class="parameter"><code>buffer</code></em> is not the name of a complete GL
+            texture object, and one or more faces do not have mipmap level 0
+            specified, the error <code class="constant">EGL_BAD_PARAMETER</code> is
+            generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code>,
+            <code class="constant">EGL_GL_RENDERBUFFER</code> or
+            <code class="constant">EGL_GL_TEXTURE_3D</code> and
+            <em class="parameter"><code>buffer</code></em> refers to the default GL texture
+            object (0) for the corresponding GL target, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_2D</code>,
+            <code class="constant">EGL_GL_TEXTURE_CUBE_MAP_*</code>, or
+            <code class="constant">EGL_GL_TEXTURE_3D</code>, and the value specified
+            in <em class="parameter"><code>attrib_list</code></em> for
+            <code class="constant">EGL_GL_TEXTURE_LEVEL</code> is not a valid mipmap
+            level for the specified GL texture object
+            <em class="parameter"><code>buffer</code></em>, the error
+            <code class="constant">EGL_BAD_MATCH</code> is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>target</code></em> is
+            <code class="constant">EGL_GL_TEXTURE_3D</code>, and the value specified
+            in <em class="parameter"><code>attrib_list</code></em> for
+            <code class="constant">EGL_GL_TEXTURE_ZOFFSET</code> exceeds the depth of
+            the specified mipmap level-of-detail in
+            <em class="parameter"><code>buffer</code></em>, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
+        </p>
+        <p>
+            If an attribute specified in <em class="parameter"><code>attrib_list</code></em>
+            is not one of the attributes shown in table <a class="xref" href="#tab-imageattr" title="Table 2.  Legal attributes for eglCreateImage attrib_list parameter">Table 2, “
+                Legal attributes for <code class="function">eglCreateImage</code>
+                <em class="parameter"><code>attrib_list</code></em> parameter
+            ”</a>, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
+        </p>
+        <p>
+            If an attribute specified in <em class="parameter"><code>attrib_list</code></em>
+            is not a valid attribute for <em class="parameter"><code>target</code></em>, as
+            shown in table <a class="xref" href="#tab-imageattr" title="Table 2.  Legal attributes for eglCreateImage attrib_list parameter">Table 2, “
+                Legal attributes for <code class="function">eglCreateImage</code>
+                <em class="parameter"><code>attrib_list</code></em> parameter
+            ”</a>, the error
+            <code class="constant">EGL_BAD_MATCH</code> is generated.
+        </p>
+        <p>
+            If the resource specified by <em class="parameter"><code>display</code></em>,
+            <em class="parameter"><code>context</code></em>, <em class="parameter"><code>target</code></em>,
+            <em class="parameter"><code>buffer</code></em> and
+            <em class="parameter"><code>attrib_list</code></em> has an off-screen buffer
+            bound to it (e.g., by a previous call to
+            <code class="function">eglBindTexImage</code>), the error
+            <code class="constant">EGL_BAD_ACCESS</code> is generated.
+        </p>
+        <p>
+            If the resource specified by <em class="parameter"><code>display</code></em>,
+            <em class="parameter"><code>context</code></em>, <em class="parameter"><code>target</code></em>,
+            <em class="parameter"><code>buffer</code></em> and
+            <em class="parameter"><code>attrib_list</code></em> is bound to an off-screen
+            buffer (e.g., by a previous call to
+            <code class="function">eglCreatePbufferFromClientBuffer</code>), the
+            error <code class="constant">EGL_BAD_ACCESS</code> is generated.
+        </p>
+        <p>
+            If the resource specified by <em class="parameter"><code>display</code></em>,
+            <em class="parameter"><code>context</code></em>, <em class="parameter"><code>target</code></em>,
+            <em class="parameter"><code>buffer</code></em> and
+            <em class="parameter"><code>attrib_list</code></em> is itself an
+            <span class="type">EGLImage</span> sibling, the error
+            <code class="constant">EGL_BAD_ACCESS</code> is generated.
+        </p>
+        <p>
+            If insufficient memory is available to complete the specified
+            operation, the error <code class="constant">EGL_BAD_ALLOC</code> is
+            generated.
+        </p>
+        <p>
+            If the value specified in <em class="parameter"><code>attrib_list</code></em> for
+            <code class="constant">EGL_IMAGE_PRESERVED</code> is
+            <code class="constant">EGL_TRUE</code>, and an <span class="type">EGLImage</span>
+            handle cannot be created from the specified resource such that
+            the pixel data values in <em class="parameter"><code>buffer</code></em> are
+            preserved, the error <code class="constant">EGL_BAD_ACCESS</code> is
+            generated.
+        </p>
+        <p>
+            Note that the success or failure of
+            <code class="function">eglCreateImage</code> should not affect the
+            ability to use <em class="parameter"><code>buffer</code></em> in its original API
+            context (or context share group) (although the pixel data values
+            will be undefined if the command succeeds and the value of
+            <code class="constant">EGL_IMAGE_PRESERVED</code> is not
+            <code class="constant">EGL_TRUE</code>).
+        </p>
+      </div>
+      <div class="refsect1" id="lifetime">
+        <h2>Lifetime and Usage of <span class="type">EGLImage</span>s</h2>
+        <p>
+            Once an <span class="type">EGLImage</span> is created from an
+            <span class="type">EGLImage</span> source, the memory associated with the
+            <span class="type">EGLImage</span> source will remain allocated (and all
+            <span class="type">EGLImage</span> siblings in all client API contexts will
+            be useable) as long as either of the following conditions is
+            true:
+        </p>
+        <p>
+            </p>
+        <div class="itemizedlist">
+          <ul class="itemizedlist" style="list-style-type: disc; ">
+            <li class="listitem">
+              <p>
+                     Any <span class="type">EGLImage</span> siblings exist in any client
+                     API context
+                </p>
+            </li>
+            <li class="listitem">
+              <p>
+                    The <span class="type">EGLImage</span> object exists inside EGL
+                </p>
+            </li>
+          </ul>
+        </div>
+        <p>
+        </p>
+        <p>
+            The semantics for specifying, deleting and using
+            <span class="type">EGLImage</span> siblings are client API-specific, and are
+            described in the appropriate API specifications.
+        </p>
+        <p>
+            If an application specifies an <span class="type">EGLImage</span> sibling as
+            the destination for rendering and/or pixel download operations
+            (e.g., as an OpenGL or OpenGL ES framebuffer object,
+            <code class="function">glTexSubImage2D</code>, etc.), the modified image
+            results will be observed by all <span class="type">EGLImage</span> siblings
+            in all client API contexts. If multiple client API contexts
+            access <span class="type">EGLImage</span> sibling resources simultaneously,
+            with one or more context modifying the image data, rendering
+            results in all contexts accessing <span class="type">EGLImage</span> siblings
+            are undefined.
+        </p>
+        <p>
+            Respecification and/or deletion of any <span class="type">EGLImage</span>
+            sibling (i.e., both <span class="type">EGLImage</span> source and
+            <span class="type">EGLImage</span> target resources) inside a client API
+            context (by issuing a subsequent call to commands such as
+            <code class="function">glTexImage*</code> or
+            <code class="function">glDeleteTextures</code>, with the
+            <span class="type">EGLImage</span> sibling resource as the target of the
+            operation) affects only that client API context and other
+            contexts within its share group. For an OpenGL or OpenGL ES
+            context, respecification always results in
+            <em class="firstterm">orphaning</em> of the <span class="type">EGLImage</span>,
+            and may also include allocation of additional memory for the
+            respecified resource and/or copying of the <span class="type">EGLImage</span>
+            pixel data.
+        </p>
+        <p>
+            Note: Behavior of other types of client APIs generally follows
+            the OpenGL and OpenGL ES behavior described here, although this
+            is not mandated yet.
+        </p>
+        <p>
+            Operations inside EGL or any client API context which may affect
+            the lifetime of an <span class="type">EGLImage</span> (or the memory
+            allocated for the <span class="type">EGLImage</span>), such as respecifying
+            and/or deleting an <span class="type">EGLImage</span> sibling inside a client
+            API context, must be atomic.
+        </p>
+        <p>
+            Applications may create client API resources from an
+            <span class="type">EGLImage</span> using client API extensions outside the
+            scope of this document (such as
+            <code class="constant">GL_OES_EGL_image</code>, which creates OpenGL ES
+            texture and renderbuffer objects). If the <span class="type">EGLImage</span>
+            used to create the client resource was created with the
+            <code class="constant">EGL_IMAGE_PRESERVED</code> attribute set to
+            <code class="constant">EGL_TRUE</code>, then the pixel data values
+            associated with the image will be preserved after creating the
+            client resource; otherwise, the pixel data values will be
+            undefined. If the <span class="type">EGLImage</span> was created with the
+            <code class="constant">EGL_IMAGE_PRESERVED</code> attribute set to
+            <code class="constant">EGL_TRUE</code>, and EGL is unable to create the
+            client resource without modifying the pixel values, then
+            creation will fail and the pixel data values will be preserved.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            <code class="function">eglCreateImage</code> is available only if the EGL
+            version is 1.5 or greater.
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglBindTexImage.xhtml"><span class="citerefentry"><span class="refentrytitle">eglBindTexImage</span></span></a>,
+            <a class="citerefentry" href="eglCreatePbufferFromClientBuffer.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePbufferFromClientBuffer</span></span></a>,
+            <a class="citerefentry" href="eglDestroyImage.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroyImage</span></span></a>,
+            <code class="function">glDeleteTextures</code>,
+            <code class="function">glTexImage*</code>,
+            <code class="function">glTexSubImage2D</code>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglCreatePbufferFromClientBuffer.xhtml
+++ b/sdk/docs/man/html/eglCreatePbufferFromClientBuffer.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreatePbufferFromClientBuffer - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -359,6 +359,11 @@
             section above.
         </p>
         <p>
+            <code class="constant">EGL_BAD_ACCESS</code> is generated if the buffers
+            contained in <em class="parameter"><code>buffer</code></em> consist of any
+            <span class="type">EGLImage</span> siblings.
+        </p>
+        <p>
             <code class="constant">EGL_BAD_ALLOC</code> is generated if there are not
             enough resources to allocate the new surface.
         </p>
@@ -383,8 +388,9 @@
         </p>
         <p>
             <code class="constant">EGL_BAD_MATCH</code> is generated if
-            <em class="parameter"><code>config</code></em> does not support rendering to pixel buffers
-            (the <code class="constant">EGL_SURFACE_TYPE</code> attribute does not contain
+            <em class="parameter"><code>config</code></em> does not support rendering to
+            pixel buffers (the <code class="constant">EGL_SURFACE_TYPE</code>
+            attribute does not contain
             <code class="constant">EGL_PBUFFER_BIT</code>).
         </p>
         <p>

--- a/sdk/docs/man/html/eglCreatePbufferSurface.xhtml
+++ b/sdk/docs/man/html/eglCreatePbufferSurface.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreatePbufferSurface - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -98,6 +98,36 @@
         </p>
         <div class="variablelist">
           <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_GL_COLORSPACE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the color space used by OpenGL and OpenGL ES
+                    when rendering to the surface. If its value is
+                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code>, then a
+                    non-linear, perceptually uniform color space is assumed,
+                    with a corresponding
+                    <code class="constant">GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>
+                    value of <code class="constant">GL_SRGB</code>. If its value is
+                    <code class="constant">EGL_GL_COLORSPACE_LINEAR</code>, then a
+                    linear color space is assumed, with a corresponding
+                    <code class="constant">GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>
+                    value of <code class="constant">GL_LINEAR</code>. The default
+                    value of <code class="constant">EGL_GL_COLORSPACE</code> is
+                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code>.
+                </p>
+              <p>
+                    Note that the <code class="constant">EGL_GL_COLORSPACE</code>
+                    attribute is used only by OpenGL and OpenGL ES contexts
+                    supporting sRGB framebuffers. EGL itself does not
+                    distinguish multiple colorspace models. Refer to the
+                    ``sRGB Conversion'' sections of the OpenGL 4.6 and
+                    OpenGL ES 3.2 Specifications for more information.
+                </p>
+            </dd>
             <dt>
               <span class="term">
                 <code class="constant">EGL_HEIGHT</code>
@@ -246,6 +276,12 @@
       <div class="refsect1" id="notes">
         <h2>Notes</h2>
         <p>
+            Attribute <code class="constant">EGL_GL_COLORSPACE</code>, and the
+            <code class="constant">EGL_OPENGL_ES3_BIT</code> bit value for attribute
+            <code class="constant">EGL_RENDERABLE_TYPE</code>, are supported only if
+            the EGL version is 1.5 or greater.
+        </p>
+        <p>
             Attributes
             <code class="constant">EGL_RENDERABLE_TYPE</code>,
             <code class="constant">EGL_VG_ALPHA_FORMAT</code>, and
@@ -314,8 +350,9 @@
             rendering (e.g. the EGL version is 1.2 or later, and the
             <code class="constant">EGL_RENDERABLE_TYPE</code> attribute of
             <em class="parameter"><code>config</code></em> does not include at least one
-            of <code class="constant">EGL_OPENGL_ES_BIT</code> or
-            <code class="constant">EGL_OPENGL_ES2_BIT</code>).
+            of <code class="constant">EGL_OPENGL_ES_BIT</code>,
+            <code class="constant">EGL_OPENGL_ES2_BIT</code>), or
+            <code class="constant">EGL_OPENGL_ES3_BIT</code>),
         </p>
         <p>
             <code class="constant">EGL_BAD_ALLOC</code> is generated if there are not

--- a/sdk/docs/man/html/eglCreatePixmapSurface.xhtml
+++ b/sdk/docs/man/html/eglCreatePixmapSurface.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreatePixmapSurface - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -12,7 +12,7 @@
       <div class="refnamediv">
         <h2>Name</h2>
         <p>eglCreatePixmapSurface — 
-            create a new <abbr class="acronym">EGL</abbr> pixmap surface
+            create a new <abbr class="acronym">EGL</abbr> offscreen surface
         </p>
       </div>
       <div class="refsynopsisdiv">
@@ -97,165 +97,28 @@
       <div class="refsect1" id="description">
         <h2>Description</h2>
         <p>
-            <code class="function">eglCreatePixmapSurface</code> creates an
-            off-screen <abbr class="acronym">EGL</abbr> pixmap surface and returns
-            its handle. If <code class="function">eglCreatePixmapSurface</code>
-            fails to create a pixmap surface,
-            <code class="constant">EGL_NO_SURFACE</code> is returned.
-        </p>
-        <p>
-            Surface attributes are specified as a list of
-            attribute-value pairs, terminated with
-            <code class="constant">EGL_NONE</code>. Accepted attributes
-            are:
-        </p>
-        <div class="variablelist">
-          <dl class="variablelist">
-            <dt>
-              <span class="term">
-                <code class="constant">EGL_VG_ALPHA_FORMAT</code>
-              </span>
-            </dt>
-            <dd>
-              <p>
-                    Specifies how alpha values are interpreted by OpenVG
-                    when rendering to the surface. If its value is
-                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>,
-                    then alpha values are not premultipled. If its value
-                    is <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code>,
-                    then alpha values are premultiplied. The default
-                    value of <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
-                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>.
-                </p>
-            </dd>
-            <dt>
-              <span class="term">
-                <code class="constant">EGL_VG_COLORSPACE</code>
-              </span>
-            </dt>
-            <dd>
-              <p>
-                    Specifies the color space used by OpenVG when
-                    rendering to the surface. If its value is
-                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>, then a
-                    non-linear, perceptually uniform color space is
-                    assumed, with a corresponding
-                    <span class="type">VGImageFormat</span> of form
-                    <code class="constant">VG_s*</code>. If its value is
-                    <code class="constant">EGL_VG_COLORSPACE_LINEAR</code>, then
-                    a linear color space is assumed, with a
-                    corresponding <span class="type">VGImageFormat</span> of form
-                    <code class="constant">VG_l*</code>. The default value of
-                    <code class="constant">EGL_VG_COLORSPACE</code> is
-                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>.
-                </p>
-            </dd>
-          </dl>
-        </div>
-        <p>
-            Any EGL rendering context that was created with respect to
-            <em class="parameter"><code>config</code></em> can be used to render into the
-            surface. Use
-            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>
-            to attach an EGL rendering context to the surface.
-        </p>
-        <p>
-            Use
-            <a class="citerefentry" href="eglQuerySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQuerySurface</span></span></a>
-            to retrieve the ID of <em class="parameter"><code>config</code></em>.
-        </p>
-        <p>
-            Use <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>
-            to destroy the surface.
-        </p>
-      </div>
-      <div class="refsect1" id="notes">
-        <h2>Notes</h2>
-        <p>
-            The <code class="constant">EGL_MATCH_NATIVE_PIXMAP</code> attribute
+            <code class="function">eglCreatePixmapSurface</code> creates an on-screen
+            EGL window surface and returns a handle to it. The behavior of
+            <code class="function">eglCreatePixmapSurface</code> is identical to that
             of
-            <a class="citerefentry" href="eglChooseConfig.xhtml"><span class="citerefentry"><span class="refentrytitle">eglChooseConfig</span></span></a>
-            can be used to select a frame buffer configuration matching
-            a specified native pixmap.
-        </p>
-        <p>
-            Attributes
-            <code class="constant">EGL_VG_ALPHA_FORMAT</code> and
-            <code class="constant">EGL_VG_COLORSPACE</code>, and the
-            corresponding attribute values, are supported only if the
-            EGL version is 1.2 or greater.
-        </p>
-        <p>
-            The <code class="constant">EGL_VG_ALPHA_FORMAT</code> and
-            <code class="constant">EGL_VG_COLORSPACE</code> attributes are used
-            only by OpenVG. EGL itself, and other client APIs such as
-            OpenGL and OpenGL ES , do not distinguish multiple
-            colorspace models. Refer to section 11.2 of the OpenVG 1.0
-            specification for more information. The native window
-            system's use and interpretation of alpha values is outside
-            the scope of EGL, although the preferred behavior is for the
-            window system to ignore the value of
-            <code class="constant">EGL_VG_ALPHA_FORMAT</code>.
+            <a class="citerefentry" href="eglCreatePlatformPixmapSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePlatformPixmapSurface</span></span></a>
+            except that the set of platforms to which
+            <em class="parameter"><code>display</code></em> is permitted to belong, as well
+            as the actual type of <em class="parameter"><code>native_pixmap</code></em>, are
+            implementation specific.
         </p>
       </div>
       <div class="refsect1" id="errors">
         <h2>Errors</h2>
         <p>
-            <code class="constant">EGL_NO_SURFACE</code> is returned if creation of
-            the context fails.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_DISPLAY</code> is generated if
-            <em class="parameter"><code>display</code></em> is not an EGL display connection.
-        </p>
-        <p>
-            <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
-            <em class="parameter"><code>display</code></em> has not been initialized.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_CONFIG</code> is generated if
-            <em class="parameter"><code>config</code></em> is not an EGL config.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_NATIVE_PIXMAP</code> may be generated if
-            <em class="parameter"><code>native_pixmap</code></em> is not a valid native pixmap.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_ATTRIBUTE</code> is generated if
-            <em class="parameter"><code>attrib_list</code></em> contains an invalid pixmap attribute
-            or if an attribute value is not recognized or out of range.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_ALLOC</code> is generated if there are not
-            enough resources to allocate the new surface.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_MATCH</code> is generated if the attributes of
-            <em class="parameter"><code>native_pixmap</code></em> do not correspond to
-            <em class="parameter"><code>config</code></em> or if
-            <em class="parameter"><code>config</code></em> does not support rendering to pixmaps
-            (the <code class="constant">EGL_SURFACE_TYPE</code> attribute does not contain
-            <code class="constant">EGL_PIXMAP_BIT</code>).
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_MATCH</code> is generated if
-            <em class="parameter"><code>config</code></em> does not support the specified
-            OpenVG alpha format attribute (the value of
-            <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
-            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code> and the
-            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE_BIT</code> is not set
-            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
-            <em class="parameter"><code>config</code></em>) or colorspace attribute (the
-            value of <code class="constant">EGL_VG_COLORSPACE</code> is
-            <code class="constant">EGL_VG_COLORSPACE_LINEAR</code> and the
-            <code class="constant">EGL_VG_COLORSPACE_LINEAR_IT</code> is not set
-            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
-            <em class="parameter"><code>config</code></em>).
+            See errors for
+            <a class="citerefentry" href="eglCreatePlatformPixmapSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePlatformPixmapSurface</span></span></a>.
         </p>
       </div>
       <div class="refsect1" id="seealso">
         <h2>See Also</h2>
         <p>
+            <a class="citerefentry" href="eglCreatePlatformPixmapSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePlatformPixmapSurface</span></span></a>,
             <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>,
             <a class="citerefentry" href="eglChooseConfig.xhtml"><span class="citerefentry"><span class="refentrytitle">eglChooseConfig</span></span></a>,
             <a class="citerefentry" href="eglGetConfigs.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetConfigs</span></span></a>,

--- a/sdk/docs/man/html/eglCreatePlatformPixmapSurface.xhtml
+++ b/sdk/docs/man/html/eglCreatePlatformPixmapSurface.xhtml
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreatePlatformPixmapSurface - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglCreatePlatformPixmapSurface">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglCreatePlatformPixmapSurface — 
+            create a new <abbr class="acronym">EGL</abbr> offscreen surface
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLSurface <strong class="fsfunc">eglCreatePlatformPixmapSurface</strong>(</code>
+              </td>
+              <td>EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLConfig <var class="pdparam">config</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>void * <var class="pdparam">native_pixmap</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLint const * <var class="pdparam">attrib_list</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>Specifies the EGL display connection.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>config</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the EGL frame buffer configuration that defines the
+                    frame buffer resource available to the surface.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>native_pixmap</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>Specifies the native pixmap.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>attrib_list</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies pixmap surface attributes.
+                    May be <code class="constant">NULL</code> or empty
+                    (first attribute is <code class="constant">EGL_NONE</code>).
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglCreatePlatformPixmapSurface</code> creates an
+            off-screen <abbr class="acronym">EGL</abbr> pixmap surface and returns
+            a handle to it.
+        </p>
+        <p>
+            If <code class="function">eglCreatePlatformPixmapSurface</code> fails to
+            create a pixmap surface, <code class="constant">EGL_NO_SURFACE</code> is
+            returned.
+        </p>
+        <p>
+            <em class="parameter"><code>native_pixmap</code></em> must belong to the same
+            platform as <em class="parameter"><code>display</code></em>, and EGL considers
+            the returned <span class="type">EGLSurface</span> as belonging to that same
+            platform. The EGL extension that defines the platform to which
+            <em class="parameter"><code>display</code></em> belongs also defines the
+            requirements for the <em class="parameter"><code>native_pixmap</code></em>
+            parameter.
+        </p>
+        <p>
+            Surface attributes are specified as a list of
+            attribute-value pairs, terminated with
+            <code class="constant">EGL_NONE</code>. Accepted attributes
+            are:
+        </p>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_GL_COLORSPACE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the color space used by OpenGL and OpenGL ES
+                    when rendering to the surface. If its value is
+                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code>, then a
+                    non-linear, perceptually uniform color space is assumed,
+                    with a corresponding
+                    <code class="constant">GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>
+                    value of <code class="constant">GL_SRGB</code>. If its value is
+                    <code class="constant">EGL_GL_COLORSPACE_LINEAR</code>, then a
+                    linear color space is assumed, with a corresponding
+                    <code class="constant">GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>
+                    value of <code class="constant">GL_LINEAR</code>. The default
+                    value of <code class="constant">EGL_GL_COLORSPACE</code> is
+                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code>.
+                </p>
+              <p>
+                    Note that the <code class="constant">EGL_GL_COLORSPACE</code>
+                    attribute is used only by OpenGL and OpenGL ES contexts
+                    supporting sRGB framebuffers. EGL itself does not
+                    distinguish multiple colorspace models. Refer to the
+                    ``sRGB Conversion'' sections of the OpenGL 4.6 and
+                    OpenGL ES 3.2 Specifications for more information.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_VG_ALPHA_FORMAT</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies how alpha values are interpreted by OpenVG
+                    when rendering to the surface. If its value is
+                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>,
+                    then alpha values are not premultipled. If its value
+                    is <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code>,
+                    then alpha values are premultiplied. The default
+                    value of <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
+                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_VG_COLORSPACE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the color space used by OpenVG when
+                    rendering to the surface. If its value is
+                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>, then a
+                    non-linear, perceptually uniform color space is
+                    assumed, with a corresponding
+                    <span class="type">VGImageFormat</span> of form
+                    <code class="constant">VG_s*</code>. If its value is
+                    <code class="constant">EGL_VG_COLORSPACE_LINEAR</code>, then
+                    a linear color space is assumed, with a
+                    corresponding <span class="type">VGImageFormat</span> of form
+                    <code class="constant">VG_l*</code>. The default value of
+                    <code class="constant">EGL_VG_COLORSPACE</code> is
+                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>.
+                </p>
+            </dd>
+          </dl>
+        </div>
+        <p>
+            Any EGL rendering context that was created with respect to
+            <em class="parameter"><code>config</code></em> can be used to render into the
+            surface. Use
+            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>
+            to attach an EGL rendering context to the surface.
+        </p>
+        <p>
+            Use
+            <a class="citerefentry" href="eglQuerySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQuerySurface</span></span></a>
+            to retrieve the ID of <em class="parameter"><code>config</code></em>.
+        </p>
+        <p>
+            Use <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>
+            to destroy the surface.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            The <code class="constant">EGL_MATCH_NATIVE_PIXMAP</code> attribute
+            of
+            <a class="citerefentry" href="eglChooseConfig.xhtml"><span class="citerefentry"><span class="refentrytitle">eglChooseConfig</span></span></a>
+            can be used to select a frame buffer configuration matching
+            a specified native pixmap.
+        </p>
+        <p>
+            Attribute <code class="constant">EGL_GL_COLORSPACE</code> is supported
+            only if the EGL version is 1.5 or greater.
+        </p>
+        <p>
+            Attributes
+            <code class="constant">EGL_VG_ALPHA_FORMAT</code> and
+            <code class="constant">EGL_VG_COLORSPACE</code>, and the
+            corresponding attribute values, are supported only if the
+            EGL version is 1.2 or greater.
+        </p>
+        <p>
+            The <code class="constant">EGL_VG_ALPHA_FORMAT</code> and
+            <code class="constant">EGL_VG_COLORSPACE</code> attributes are used only
+            by OpenVG and EGL itself. Refer to section 11.2 of the OpenVG
+            1.0 specification for more information. The platform's use and
+            interpretation of alpha values is outside the scope of EGL.
+            However, the preferred behavior is for the window system to
+            ignore the value of <code class="constant">EGL_VG_ALPHA_FORMAT</code>.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            If <em class="parameter"><code>display</code></em> and
+            <em class="parameter"><code>native_pixmap</code></em> do not belong to the same
+            platform, then undefined behavior occurs.
+        </p>
+        <p>
+            <code class="constant">EGL_NO_SURFACE</code> is returned if creation of
+            the surface fails.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_DISPLAY</code> is generated if
+            <em class="parameter"><code>display</code></em> is not an EGL display connection.
+        </p>
+        <p>
+            <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
+            <em class="parameter"><code>display</code></em> has not been initialized.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_CONFIG</code> is generated if
+            <em class="parameter"><code>config</code></em> is not an EGL config.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_NATIVE_PIXMAP</code> may be generated if
+            <em class="parameter"><code>native_pixmap</code></em> is not a valid native pixmap.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_ATTRIBUTE</code> is generated if
+            <em class="parameter"><code>attrib_list</code></em> contains an invalid pixmap attribute
+            or if an attribute value is not recognized or out of range.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_ALLOC</code> is generated if there is
+            already an <span class="type">EGLSurface</span> associated with
+            <em class="parameter"><code>native_pixmap</code></em> (as a result of a previous
+            <code class="function">eglCreatePlatformPixmapSurface</code> call).
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_ALLOC</code> is generated if the
+            implementation cannot allocate resources for the new EGL window.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_MATCH</code> is generated if the attributes of
+            <em class="parameter"><code>native_pixmap</code></em> do not correspond to
+            <em class="parameter"><code>config</code></em> or if
+            <em class="parameter"><code>config</code></em> does not support rendering to pixmaps
+            (the <code class="constant">EGL_SURFACE_TYPE</code> attribute does not contain
+            <code class="constant">EGL_PIXMAP_BIT</code>).
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_MATCH</code> is generated if
+            <em class="parameter"><code>config</code></em> does not support the specified
+            OpenVG alpha format attribute (the value of
+            <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
+            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code> and the
+            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE_BIT</code> is not set
+            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
+            <em class="parameter"><code>config</code></em>) or colorspace attribute (the
+            value of <code class="constant">EGL_VG_COLORSPACE</code> is
+            <code class="constant">EGL_VG_COLORSPACE_LINEAR</code> and the
+            <code class="constant">EGL_VG_COLORSPACE_LINEAR_IT</code> is not set
+            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
+            <em class="parameter"><code>config</code></em>).
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>,
+            <a class="citerefentry" href="eglChooseConfig.xhtml"><span class="citerefentry"><span class="refentrytitle">eglChooseConfig</span></span></a>,
+            <a class="citerefentry" href="eglGetConfigs.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetConfigs</span></span></a>,
+            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>,
+            <a class="citerefentry" href="eglQuerySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQuerySurface</span></span></a>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglCreatePlatformWindowSurface.xhtml
+++ b/sdk/docs/man/html/eglCreatePlatformWindowSurface.xhtml
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreatePlatformWindowSurface - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglCreatePlatformWindowSurface">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglCreatePlatformWindowSurface — 
+            create a new <abbr class="acronym">EGL</abbr> on-screen rendering surface
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLSurface <strong class="fsfunc">eglCreatePlatformWindowSurface</strong>(</code>
+              </td>
+              <td>EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLConfig <var class="pdparam">config</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>void * <var class="pdparam">native_window</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLAttrib const * <var class="pdparam">attrib_list</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>Specifies the EGL display connection.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>config</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>Specifies the EGL frame buffer configuration that defines the
+                    frame buffer resource available to the surface.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>native_window</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>Specifies the native window.</p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>attrib_list</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies a list of attributes for the window surface.
+                    May be <code class="constant">NULL</code> or empty
+                    (first attribute is <code class="constant">EGL_NONE</code>).
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglCreatePlatformWindowSurface</code> creates an
+            on-screen EGL window surface and returns a handle to it. Any EGL
+            context created with a compatible <span class="type">EGLConfig</span> can be
+            used to render into this surface.
+        </p>
+        <p>
+            If <code class="function">eglCreatePlatformWindowSurface</code> fails to
+            create a window surface, <code class="constant">EGL_NO_SURFACE</code> is
+            returned.
+        </p>
+        <p>
+            <em class="parameter"><code>native_window</code></em> must belong to the same
+            platform as <em class="parameter"><code>display</code></em>, and EGL considers
+            the returned <span class="type">EGLSurface</span> as belonging to that same
+            platform. The EGL extension that defines the platform to which
+            <em class="parameter"><code>display</code></em> belongs also defines the
+            requirements for the <em class="parameter"><code>native_window</code></em>
+            parameter.
+        </p>
+        <p>
+            Surface attributes are specified as a list of
+            attribute-value pairs, terminated with
+            <code class="constant">EGL_NONE</code>. Accepted attributes
+            are:
+        </p>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_GL_COLORSPACE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the color space used by OpenGL and OpenGL ES
+                    when rendering to the surface. If its value is
+                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code>, then a
+                    non-linear, perceptually uniform color space is assumed,
+                    with a corresponding
+                    <code class="constant">GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>
+                    value of <code class="constant">GL_SRGB</code>. If its value is
+                    <code class="constant">EGL_GL_COLORSPACE_LINEAR</code>, then a
+                    linear color space is assumed, with a corresponding
+                    <code class="constant">GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>
+                    value of <code class="constant">GL_LINEAR</code>. The default
+                    value of <code class="constant">EGL_GL_COLORSPACE</code> is
+                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code>.
+                </p>
+              <p>
+                    Note that the <code class="constant">EGL_GL_COLORSPACE</code>
+                    attribute is used only by OpenGL and OpenGL ES contexts
+                    supporting sRGB framebuffers. EGL itself does not
+                    distinguish multiple colorspace models. Refer to the
+                    ``sRGB Conversion'' sections of the OpenGL 4.6 and
+                    OpenGL ES 3.2 Specifications for more information.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_RENDER_BUFFER</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies which buffer should be used for client API
+                    rendering to the window. If its value is
+                    <code class="constant">EGL_SINGLE_BUFFER</code>, then client
+                    APIs should render directly into the visible window.
+                    If its value is
+                    <code class="constant">EGL_BACK_BUFFER</code>, then client
+                    APIs should render into the back buffer. The default
+                    value of <code class="constant">EGL_RENDER_BUFFER</code> is
+                    <code class="constant">EGL_BACK_BUFFER</code>.
+                </p>
+              <p>
+                    Client APIs may not be able to respect the requested
+                    rendering buffer. To determine the actual buffer
+                    being rendered to by a context, call
+                    <a class="citerefentry" href="eglQueryContext.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryContext</span></span></a>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_VG_ALPHA_FORMAT</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies how alpha values are interpreted by OpenVG
+                    when rendering to the surface. If its value is
+                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>,
+                    then alpha values are not premultipled. If its value
+                    is <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code>,
+                    then alpha values are premultiplied. The default
+                    value of <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
+                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_VG_COLORSPACE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the color space used by OpenVG when
+                    rendering to the surface. If its value is
+                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>, then a
+                    non-linear, perceptually uniform color space is
+                    assumed, with a corresponding
+                    <span class="type">VGImageFormat</span> of form
+                    <code class="constant">VG_s*</code>. If its value is
+                    <code class="constant">EGL_VG_COLORSPACE_LINEAR</code>, then
+                    a linear color space is assumed, with a
+                    corresponding <span class="type">VGImageFormat</span> of form
+                    <code class="constant">VG_l*</code>. The default value of
+                    <code class="constant">EGL_VG_COLORSPACE</code> is
+                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>.
+                </p>
+            </dd>
+          </dl>
+        </div>
+        <p>
+            Any EGL rendering context that was created with respect to
+            <em class="parameter"><code>config</code></em> can be used to render into the
+            surface. Use
+            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>
+            to attach an EGL rendering context to the surface.
+        </p>
+        <p>
+            Use
+            <a class="citerefentry" href="eglQuerySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQuerySurface</span></span></a>
+            to retrieve the ID of <em class="parameter"><code>config</code></em>.
+        </p>
+        <p>
+            Use
+            <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>
+            to destroy the surface.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            Attribute <code class="constant">EGL_GL_COLORSPACE</code> is supported
+            only if the EGL version is 1.5 or greater.
+        </p>
+        <p>
+            Attributes <code class="constant">EGL_RENDER_BUFFER</code>,
+            <code class="constant">EGL_VG_ALPHA_FORMAT</code>, and
+            <code class="constant">EGL_VG_COLORSPACE</code>, and the
+            corresponding attribute values, are supported only if the
+            EGL version is 1.2 or greater.
+        </p>
+        <p>
+            The <code class="constant">EGL_VG_ALPHA_FORMAT</code> and
+            <code class="constant">EGL_VG_COLORSPACE</code> attributes are used only
+            by OpenVG and EGL itself. Refer to section 11.2 of the OpenVG
+            1.0 specification for more information. The platform's use and
+            interpretation of alpha values is outside the scope of EGL.
+            However, the preferred behavior is for platforms to ignore the
+            value of <code class="constant">EGL_VG_ALPHA_FORMAT</code> when
+            compositing window surfaces.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            If <em class="parameter"><code>display</code></em> and
+            <em class="parameter"><code>native_window</code></em> do not belong to the same
+            platform, then undefined behavior occurs.
+        </p>
+        <p>
+            <code class="constant">EGL_NO_SURFACE</code> is returned if creation of
+            the surface fails.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_DISPLAY</code> is generated if
+            <em class="parameter"><code>display</code></em> is not an EGL display connection.
+        </p>
+        <p>
+            <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
+            <em class="parameter"><code>display</code></em> has not been initialized.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_CONFIG</code> is generated if
+            <em class="parameter"><code>config</code></em> is not a valid EGL frame buffer
+            configuration.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_NATIVE_WINDOW</code> may be generated if
+            <em class="parameter"><code>native_window</code></em> is not a valid native
+            window for the same platform as <em class="parameter"><code>display</code></em>.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_ATTRIBUTE</code> is generated if
+            <em class="parameter"><code>attrib_list</code></em> contains an invalid window attribute
+            or if an attribute value is not recognized or is out of range.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_ALLOC</code> is generated if there is
+            already an <span class="type">EGLSurface</span> associated with
+            <em class="parameter"><code>native_window</code></em> (as a result of a previous
+            <code class="function">eglCreatePlatformWindowSurface</code> call).
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_ALLOC</code> is generated if the
+            implementation cannot allocate resources for the new EGL window.
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_MATCH</code> is generated if the pixel
+            format of <em class="parameter"><code>native_window</code></em> does not
+            correspond to the format, type, and size of the color buffers
+            required by <em class="parameter"><code>config</code></em>.
+            <code class="constant">EGL_BAD_MATCH</code> is generated if the pixel
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_MATCH</code> is generated if
+            <em class="parameter"><code>config</code></em> does not support rendering to
+            windows (the <code class="constant">EGL_SURFACE_TYPE</code> attribute
+            does not contain <code class="constant">EGL_WINDOW_BIT</code>).
+        </p>
+        <p>
+            <code class="constant">EGL_BAD_MATCH</code> is generated if
+            <em class="parameter"><code>config</code></em> does not support the specified
+            OpenVG alpha format attribute (the value of
+            <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
+            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code> and the
+            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE_BIT</code> is not set
+            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
+            <em class="parameter"><code>config</code></em>) or colorspace attribute (the
+            value of <code class="constant">EGL_VG_COLORSPACE</code> is
+            <code class="constant">EGL_VG_COLORSPACE_LINEAR</code> and the
+            <code class="constant">EGL_VG_COLORSPACE_LINEAR_IT</code> is not set
+            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
+            <em class="parameter"><code>config</code></em>).
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglCreateWindowSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateWindowSurface</span></span></a>,
+            <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>,
+            <a class="citerefentry" href="eglChooseConfig.xhtml"><span class="citerefentry"><span class="refentrytitle">eglChooseConfig</span></span></a>,
+            <a class="citerefentry" href="eglGetConfigs.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetConfigs</span></span></a>,
+            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>,
+            <a class="citerefentry" href="eglQuerySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQuerySurface</span></span></a>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglCreateSync.xhtml
+++ b/sdk/docs/man/html/eglCreateSync.xhtml
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreateSync - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglCreateSync">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglCreateSync — 
+            create a new <abbr class="acronym">EGL</abbr> sync object
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLSync <strong class="fsfunc">eglCreateSync</strong>(</code>
+              </td>
+              <td>EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLEnum <var class="pdparam">type</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLAttrib const * <var class="pdparam">attrib_list</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the <abbr class="acronym">EGL</abbr> display connection.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>type</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the type of sync object to create.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>attrib_list</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies attributes and attribute values for the sync
+                    object being created.
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <em class="firstterm">sync objects</em> are provided to enable
+            synchronization of client API operations between threads and/or
+            between API contexts. Sync objects may be tested or waited upon
+            by application threads.
+        </p>
+        <p>
+            Sync objects have a status with two possible states:
+            <em class="firstterm">signaled</em> and
+            <em class="firstterm">unsignaled</em>. Initially, sync objects are
+            unsignaled. EGL may be asked to wait for a sync object to become
+            signaled, or a sync object's status may be queried.
+        </p>
+        <p>
+            Depending on the type of a sync object, its status may be
+            changed either by an external event, or by explicitly signaling
+            and unsignaling the sync.
+        </p>
+        <p>
+            <code class="function">eglCreateSync</code> creates a sync object of the specified
+            <em class="parameter"><code>type</code></em> associated with the specified display
+            <em class="parameter"><code>display</code></em>, and returns a handle to the new object.
+            <em class="parameter"><code>attrib_list</code></em> is an attribute-value list specifying
+            other attributes of the sync object, terminated by an attribute entry
+            <code class="constant">EGL_NONE</code>. Attributes not specified in the list will be
+            assigned their default values.
+        </p>
+        <p>
+            Once the <em class="firstterm">condition</em> of the sync object is satisfied,
+            the sync is signaled, causing any <code class="function">eglClientWaitSync</code> or
+            <code class="function">eglWaitSync</code> commands blocking on
+            <em class="parameter"><code>sync</code></em> to unblock.
+        </p>
+      </div>
+      <div class="refsect1" id="fencesync">
+        <h2>Creating Fence Sync Objects</h2>
+        <p>
+            If <em class="parameter"><code>type</code></em> is
+            <code class="constant">EGL_SYNC_FENCE</code>, a fence sync object is
+            created. In this case <em class="parameter"><code>attrib_list</code></em> must be
+            <code class="constant">NULL</code> or empty (containing only
+            <code class="constant">EGL_NONE</code>). Attributes of the fence sync
+            object, and their initial values, are:
+        </p>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_SYNC_TYPE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        <code class="constant">EGL_SYNC_FENCE</code>
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_SYNC_STATUS</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        <code class="constant">EGL_UNSIGNALED</code>
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_SYNC_CONDITION</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        <code class="constant">EGL_SYNC_PRIOR_COMMANDS_COMPLETE</code>
+                    </p>
+            </dd>
+          </dl>
+        </div>
+        <p>
+            When a fence sync object is created, <code class="function">eglCreateSync</code> also inserts a
+            fence command into the command stream of the bound client API's current
+            context (i.e., the context returned by <code class="function">eglGetCurrentContext</code>), and
+            associates it with the newly created sync object.
+        </p>
+        <p>
+            The only condition supported for fence sync objects is
+            <code class="constant">EGL_SYNC_PRIOR_COMMANDS_COMPLETE</code>, which is satisfied by completion of
+            the fence command corresponding to the sync object, and all preceding
+            commands in the associated client API context's command stream. The sync
+            object will not be signaled until all effects from these commands on the
+            client API's internal and framebuffer state are fully realized. No other
+            state is affected by execution of the fence command.
+        </p>
+        <p>
+            Creation of fence sync objects requires support from the bound
+            client API, and will not succeed unless the client API satisfies
+            one of the following properties. Note that
+            <code class="function">eglWaitSync</code> also requires satisfying these
+            conditions.
+        </p>
+        <p>
+            </p>
+        <div class="itemizedlist">
+          <ul class="itemizedlist" style="list-style-type: disc; ">
+            <li class="listitem">
+              <p>
+                    client API is OpenGL, and either the OpenGL version is
+                    3.2 or greater, or the <code class="constant">GL_ARB_sync</code>
+                    extension is supported.
+                </p>
+            </li>
+            <li class="listitem">
+              <p>
+                    client API is OpenGL ES, and either the OpenGL ES
+                    version is 3.0 or greater, or the
+                    <code class="constant">GL_OES_EGL_sync</code> extension is
+                    supported.
+                </p>
+            </li>
+            <li class="listitem">
+              <p>
+                    client API is OpenVG, and the
+                    <code class="constant">VG_KHR_EGL_sync</code> extension is
+                    supported.
+                </p>
+            </li>
+          </ul>
+        </div>
+        <p>
+        </p>
+      </div>
+      <div class="refsect1" id="openclsync">
+        <h2>Creating OpenCL Event Sync Objects</h2>
+        <p>
+            If <em class="parameter"><code>type</code></em> is
+            <code class="constant">EGL_SYNC_CL_EVENT</code>, an OpenCL event sync
+            object is created. In this case
+            <em class="parameter"><code>attrib_list</code></em> must contain the attribute
+            <code class="constant">EGL_CL_EVENT_HANDLE</code>, set to a valid OpenCL
+            event handle returned by a call to
+            <code class="function">clEnqueueReleaseGLObjects</code> or
+            <code class="function">clEnqueueReleaseEGLObjects</code>; other types of
+            OpenCL event handles are not supported. Note that
+            <code class="constant">EGL_CL_EVENT_HANDLE</code> is not a queriable
+            property of a sync object. Attributes of the OpenCL event sync
+            object, and their initial values, are:
+        </p>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_SYNC_TYPE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        <code class="constant">EGL_SYNC_CL_EVENT</code>
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_SYNC_STATUS</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        Depends on status of <em class="parameter"><code>event</code></em>
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_SYNC_CONDITION</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        <code class="constant">EGL_SYNC_CL_EVENT_COMPLETE</code>
+                    </p>
+            </dd>
+          </dl>
+        </div>
+        <p>
+            The status of such a sync object depends on
+            <em class="parameter"><code>event</code></em>. When the status of
+            <em class="parameter"><code>event</code></em> is <code class="constant">CL_QUEUED</code>,
+            <code class="constant">CL_SUBMITTED</code>, or
+            <code class="constant">CL_RUNNING</code>, the status of the linked sync
+            object will be <code class="constant">EGL_UNSIGNALED</code>. When the
+            status of <em class="parameter"><code>event</code></em> changes to
+            <code class="constant">CL_COMPLETE</code>, the status of the linked sync
+            object will become <code class="constant">EGL_SIGNALED</code>.
+        </p>
+        <p>
+            The only condition supported for OpenCL event sync objects is
+            <code class="constant">EGL_SYNC_CL_EVENT_COMPLETE</code>, which is
+            satisfied when the status of the OpenCL event associated with
+            the sync object changes to <code class="constant">CL_COMPLETE</code>.
+        </p>
+        <p>
+            Creating a linked sync object places a reference on the linked
+            OpenCL event object. When the sync object is deleted, the
+            reference will be removed from the event object.
+        </p>
+        <p>
+            However, implementations are not required to validate the OpenCL
+            event, and passing an invalid event handle in
+            <em class="parameter"><code>attrib_list</code></em> may result in undefined
+            behavior up to and including program termination.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            <code class="function">eglCreateSync</code> is supported only if the EGL
+            version is 1.5 or greater.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            <code class="function">eglCreateSync</code> returns
+            <code class="constant">EGL_NO_SYNC</code> on failure.
+        </p>
+        <p>
+            If <em class="parameter"><code>display</code></em> is not the name of a valid,
+            initialized <span class="type">EGLDisplay</span>, an
+            <code class="constant">EGL_BAD_DISPLAY</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>attrib_list</code></em> contains an attribute name
+            not defined for the type of sync object being created, an
+            <code class="constant">EGL_BAD_ATTRIBUTE</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>type</code></em> is not a supported type of sync
+            object, an <code class="constant">EGL_BAD_PARAMETER</code> error is
+            generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>type</code></em> is
+            <code class="constant">EGL_SYNC_FENCE</code> and no context is current
+            for the bound API (i.e.,
+            <code class="function">eglGetCurrentContext</code> returns
+            <code class="constant">EGL_NO_CONTEXT</code>), an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>type</code></em> is
+            <code class="constant">EGL_SYNC_FENCE</code> and
+            <em class="parameter"><code>display</code></em> does not match the
+            <span class="type">EGLDisplay</span> of the currently bound context for the
+            currently bound client API (the <span class="type">EGLDisplay</span> returned
+            by <code class="function">eglGetCurrentDisplay</code>), an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>type</code></em> is
+            <code class="constant">EGL_SYNC_FENCE</code> and the current context for
+            the currently bound client API does not support fence commands,
+            an <code class="constant">EGL_BAD_MATCH</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>type</code></em> is
+            <code class="constant">EGL_SYNC_CL_EVENT</code> and
+            <code class="constant">EGL_CL_EVENT_HANDLE</code> is not specified in
+            <em class="parameter"><code>attrib_list</code></em>, or its attribute value is
+            not a valid OpenCL event handle as described above, then an
+            <code class="constant">EGL_BAD_ATTRIBUTE</code> error is generated.
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <code class="function">clEnqueueReleaseGLObjects</code>,
+            <code class="function">clEnqueueReleaseEGLObjects</code>,
+            <a class="citerefentry" href="eglClientWaitSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglClientWaitSync</span></span></a>,
+            <a class="citerefentry" href="eglCreateSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateSync</span></span></a>,
+            <a class="citerefentry" href="eglGetCurrentContext.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetCurrentContext</span></span></a>,
+            <a class="citerefentry" href="eglGetCurrentDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetCurrentDisplay</span></span></a>,
+            <a class="citerefentry" href="eglWaitSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitSync</span></span></a>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglCreateWindowSurface.xhtml
+++ b/sdk/docs/man/html/eglCreateWindowSurface.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglCreateWindowSurface - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -96,184 +96,28 @@
       <div class="refsect1" id="description">
         <h2>Description</h2>
         <p>
-            <code class="function">eglCreateWindowSurface</code> creates an EGL
-            window surface and returns its handle. If
-            <code class="function">eglCreateWindowSurface</code> fails to create
-            a window surface, <code class="constant">EGL_NO_SURFACE</code> is
-            returned.
-        </p>
-        <p>
-            Surface attributes are specified as a list of
-            attribute-value pairs, terminated with
-            <code class="constant">EGL_NONE</code>. Accepted attributes
-            are:
-        </p>
-        <div class="variablelist">
-          <dl class="variablelist">
-            <dt>
-              <span class="term">
-                <code class="constant">EGL_RENDER_BUFFER</code>
-              </span>
-            </dt>
-            <dd>
-              <p>
-                    Specifies which buffer should be used for client API
-                    rendering to the window. If its value is
-                    <code class="constant">EGL_SINGLE_BUFFER</code>, then client
-                    APIs should render directly into the visible window.
-                    If its value is
-                    <code class="constant">EGL_BACK_BUFFER</code>, then client
-                    APIs should render into the back buffer. The default
-                    value of <code class="constant">EGL_RENDER_BUFFER</code> is
-                    <code class="constant">EGL_BACK_BUFFER</code>.
-                </p>
-              <p>
-                    Client APIs may not be able to respect the requested
-                    rendering buffer. To determine the actual buffer
-                    being rendered to by a context, call
-                    <a class="citerefentry" href="eglQueryContext.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryContext</span></span></a>.
-                </p>
-            </dd>
-            <dt>
-              <span class="term">
-                <code class="constant">EGL_VG_ALPHA_FORMAT</code>
-              </span>
-            </dt>
-            <dd>
-              <p>
-                    Specifies how alpha values are interpreted by OpenVG
-                    when rendering to the surface. If its value is
-                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>,
-                    then alpha values are not premultipled. If its value
-                    is <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code>,
-                    then alpha values are premultiplied. The default
-                    value of <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
-                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code>.
-                </p>
-            </dd>
-            <dt>
-              <span class="term">
-                <code class="constant">EGL_VG_COLORSPACE</code>
-              </span>
-            </dt>
-            <dd>
-              <p>
-                    Specifies the color space used by OpenVG when
-                    rendering to the surface. If its value is
-                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>, then a
-                    non-linear, perceptually uniform color space is
-                    assumed, with a corresponding
-                    <span class="type">VGImageFormat</span> of form
-                    <code class="constant">VG_s*</code>. If its value is
-                    <code class="constant">EGL_VG_COLORSPACE_LINEAR</code>, then
-                    a linear color space is assumed, with a
-                    corresponding <span class="type">VGImageFormat</span> of form
-                    <code class="constant">VG_l*</code>. The default value of
-                    <code class="constant">EGL_VG_COLORSPACE</code> is
-                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code>.
-                </p>
-            </dd>
-          </dl>
-        </div>
-        <p>
-            Any EGL rendering context that was created with respect to
-            <em class="parameter"><code>config</code></em> can be used to render into the
-            surface. Use
-            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>
-            to attach an EGL rendering context to the surface.
-        </p>
-        <p>
-            Use
-            <a class="citerefentry" href="eglQuerySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQuerySurface</span></span></a>
-            to retrieve the ID of <em class="parameter"><code>config</code></em>.
-        </p>
-        <p>
-            Use
-            <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>
-            to destroy the surface.
-        </p>
-      </div>
-      <div class="refsect1" id="notes">
-        <h2>Notes</h2>
-        <p>
-            Attributes <code class="constant">EGL_RENDER_BUFFER</code>,
-            <code class="constant">EGL_VG_ALPHA_FORMAT</code>, and
-            <code class="constant">EGL_VG_COLORSPACE</code>, and the
-            corresponding attribute values, are supported only if the
-            EGL version is 1.2 or greater.
-        </p>
-        <p>
-            The <code class="constant">EGL_VG_ALPHA_FORMAT</code> and
-            <code class="constant">EGL_VG_COLORSPACE</code> attributes are used
-            only by OpenVG. EGL itself, and other client APIs such as
-            OpenGL and OpenGL ES , do not distinguish multiple
-            colorspace models. Refer to section 11.2 of the OpenVG 1.0
-            specification for more information. The native window
-            system's use and interpretation of alpha values is outside
-            the scope of EGL, although the preferred behavior is for the
-            window system to ignore the value of
-            <code class="constant">EGL_VG_ALPHA_FORMAT</code> when compositing
-            window surfaces.
+            <code class="function">eglCreateWindowSurface</code> creates an on-screen
+            EGL window surface and returns a handle to it. The behavior of
+            <code class="function">eglCreateWindowSurface</code> is identical to that
+            of
+            <a class="citerefentry" href="eglCreatePlatformWindowSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePlatformWindowSurface</span></span></a>
+            except that the set of platforms to which
+            <em class="parameter"><code>display</code></em> is permitted to belong, as well
+            as the actual type of <em class="parameter"><code>native_window</code></em>, are
+            implementation specific.
         </p>
       </div>
       <div class="refsect1" id="errors">
         <h2>Errors</h2>
         <p>
-            <code class="constant">EGL_NO_SURFACE</code> is returned if creation of
-            the context fails.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_DISPLAY</code> is generated if
-            <em class="parameter"><code>display</code></em> is not an EGL display connection.
-        </p>
-        <p>
-            <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
-            <em class="parameter"><code>display</code></em> has not been initialized.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_CONFIG</code> is generated if
-            <em class="parameter"><code>config</code></em> is not an EGL frame buffer configuration.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_NATIVE_WINDOW</code> may be generated if
-            <em class="parameter"><code>native_window</code></em> is not a valid native window.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_ATTRIBUTE</code> is generated if
-            <em class="parameter"><code>attrib_list</code></em> contains an invalid window attribute
-            or if an attribute value is not recognized or is out of range.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_ALLOC</code> is generated if there are not
-            enough resources to allocate the new surface.
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_MATCH</code> is generated if the attributes of
-            <em class="parameter"><code>native_window</code></em> do not correspond to
-            <em class="parameter"><code>config</code></em> or if
-            <em class="parameter"><code>config</code></em> does not support rendering to windows
-            (the <code class="constant">EGL_SURFACE_TYPE</code> attribute does not contain
-            <code class="constant">EGL_WINDOW_BIT</code>).
-        </p>
-        <p>
-            <code class="constant">EGL_BAD_MATCH</code> is generated if
-            <em class="parameter"><code>config</code></em> does not support the specified
-            OpenVG alpha format attribute (the value of
-            <code class="constant">EGL_VG_ALPHA_FORMAT</code> is
-            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code> and the
-            <code class="constant">EGL_VG_ALPHA_FORMAT_PRE_BIT</code> is not set
-            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
-            <em class="parameter"><code>config</code></em>) or colorspace attribute (the
-            value of <code class="constant">EGL_VG_COLORSPACE</code> is
-            <code class="constant">EGL_VG_COLORSPACE_LINEAR</code> and the
-            <code class="constant">EGL_VG_COLORSPACE_LINEAR_IT</code> is not set
-            in the <code class="constant">EGL_SURFACE_TYPE</code> attribute of
-            <em class="parameter"><code>config</code></em>).
+            See errors for
+            <a class="citerefentry" href="eglCreatePlatformWindowSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePlatformWindowSurface</span></span></a>.
         </p>
       </div>
       <div class="refsect1" id="seealso">
         <h2>See Also</h2>
         <p>
+            <a class="citerefentry" href="eglCreatePlatformWindowSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePlatformWindowSurface</span></span></a>,
             <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>,
             <a class="citerefentry" href="eglChooseConfig.xhtml"><span class="citerefentry"><span class="refentrytitle">eglChooseConfig</span></span></a>,
             <a class="citerefentry" href="eglGetConfigs.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetConfigs</span></span></a>,

--- a/sdk/docs/man/html/eglDestroyContext.xhtml
+++ b/sdk/docs/man/html/eglDestroyContext.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglDestroyContext - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglDestroyImage.xhtml
+++ b/sdk/docs/man/html/eglDestroyImage.xhtml
@@ -52,7 +52,7 @@
             <dt>
               <span class="term">
                 <em class="parameter">
-                  <code>sync</code>
+                  <code>image</code>
                 </em>
               </span>
             </dt>

--- a/sdk/docs/man/html/eglDestroyImage.xhtml
+++ b/sdk/docs/man/html/eglDestroyImage.xhtml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglDestroySurface - EGL Reference Pages</title>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglDestroyImage - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
     <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
-    <div class="refentry" id="eglDestroySurface">
+    <div class="refentry" id="eglDestroyImage">
       <div class="titlepage"/>
       <div class="refnamediv">
         <h2>Name</h2>
-        <p>eglDestroySurface — 
-            destroy an <abbr class="acronym">EGL</abbr> surface
+        <p>eglDestroyImage — 
+            Destroy an <span class="type">EGLImage</span> object
         </p>
       </div>
       <div class="refsynopsisdiv">
@@ -21,13 +21,13 @@
           <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
             <tr>
               <td>
-                <code class="funcdef">EGLBoolean <strong class="fsfunc">eglDestroySurface</strong>(</code>
+                <code class="funcdef">EGLBoolean <strong class="fsfunc">eglDestroyImage</strong>(</code>
               </td>
-              <td>EGLDisplay <var class="pdparam">display</var>, </td>
+              <td>(EGLDisplay <var class="pdparam">display</var>, </td>
             </tr>
             <tr>
               <td> </td>
-              <td>EGLSurface <var class="pdparam">surface</var><code>)</code>;</td>
+              <td>EGLImage <var class="pdparam">image</var><code>)</code>;</td>
             </tr>
           </table>
           <div class="funcprototype-spacer"> </div>
@@ -45,17 +45,20 @@
               </span>
             </dt>
             <dd>
-              <p>Specifies the EGL display connection.</p>
+              <p>
+                    Specifies the <abbr class="acronym">EGL</abbr> display connection.
+                </p>
             </dd>
             <dt>
               <span class="term">
                 <em class="parameter">
-                  <code>surface</code>
+                  <code>sync</code>
                 </em>
               </span>
             </dt>
             <dd>
-              <p>Specifies the EGL surface to be destroyed.
+              <p>
+                    Specifies the image to destroy.
                 </p>
             </dd>
           </dl>
@@ -64,40 +67,46 @@
       <div class="refsect1" id="description">
         <h2>Description</h2>
         <p>
-            If the EGL surface <em class="parameter"><code>surface</code></em> is not current to any
-            thread, <code class="function">eglDestroySurface</code> destroys it immediately.
-            Otherwise, <em class="parameter"><code>surface</code></em> is destroyed when it becomes
-            not current to any thread.
-            Furthermore, resources associated with a pbuffer surface are not released until
-            all color buffers of that pbuffer bound to a texture object have been released.
+            <code class="function">eglDestroyImage</code> is used to destroy the
+            specified <span class="type">EGLImage</span> object
+            <em class="parameter"><code>image</code></em>. Once destroyed,
+            <em class="parameter"><code>image</code></em> may not be used to create any
+            additional <span class="type">EGLImage</span> target resources within any
+            client API contexts, although existing <span class="type">EGLImage</span>
+            siblings may continue to be used. <code class="constant">EGL_TRUE</code>
+            is returned on success.
         </p>
       </div>
       <div class="refsect1" id="errors">
         <h2>Errors</h2>
         <p>
-            <code class="constant">EGL_FALSE</code> is returned if destruction of
-            the surface fails, <code class="constant">EGL_TRUE</code> otherwise.
+            On failure, <code class="function">eglDestroyImage</code> returns
+            <code class="constant">EGL_FALSE</code>
         </p>
         <p>
-            <code class="constant">EGL_BAD_DISPLAY</code> is generated if
-            <em class="parameter"><code>display</code></em> is not an EGL display connection.
+            If <em class="parameter"><code>display</code></em> is not the handle of a valid
+            <span class="type">EGLDisplay</span> object, the error
+            <code class="constant">EGL_BAD_DISPLAY</code> is generated.
         </p>
         <p>
-            <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
-            <em class="parameter"><code>display</code></em> has not been initialized.
+            If <em class="parameter"><code>image</code></em> is not a valid
+            <span class="type">EGLImage</span> object created with respect to
+            <em class="parameter"><code>display</code></em>, the error
+            <code class="constant">EGL_BAD_PARAMETER</code> is generated.
         </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
         <p>
-            <code class="constant">EGL_BAD_SURFACE</code> is generated if
-            <em class="parameter"><code>surface</code></em> is not an EGL surface.
+            <code class="function">eglDestroyImage</code> is available only if the
+            EGL version is 1.5 or greater.
         </p>
       </div>
       <div class="refsect1" id="seealso">
         <h2>See Also</h2>
         <p>
-            <a class="citerefentry" href="eglCreatePbufferSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePbufferSurface</span></span></a>,
-            <a class="citerefentry" href="eglCreatePixmapSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreatePixmapSurface</span></span></a>,
-            <a class="citerefentry" href="eglCreateWindowSurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateWindowSurface</span></span></a>,
-            <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>    </p>
+            <a class="citerefentry" href="eglCreateImage.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateImage</span></span></a>
+        </p>
       </div>
       <p>
     </p>

--- a/sdk/docs/man/html/eglDestroySync.xhtml
+++ b/sdk/docs/man/html/eglDestroySync.xhtml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglDestroySync - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglDestroySync">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglDestroySync — 
+            Destroy a sync object
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLBoolean <strong class="fsfunc">eglDestroySync</strong>(</code>
+              </td>
+              <td>(EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLSync <var class="pdparam">sync</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the <abbr class="acronym">EGL</abbr> display connection.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>sync</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the sync object to destroy.
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglDestroySync</code> is used to destroy an
+            existing sync object.
+        </p>
+        <p>
+            If any <code class="function">eglClientWaitSync</code> or
+            <code class="function">eglWaitSync</code> commands are blocking on
+            <em class="parameter"><code>sync</code></em> when
+            <code class="function">eglDestroySync</code> is called,
+            <em class="parameter"><code>sync</code></em> is flagged for deletion and will be
+            deleted when the associated fence command or OpenCL event object
+            has completed, and <em class="parameter"><code>sync</code></em> is no longer
+            blocking any such <code class="function">egl*WaitSync</code> command.
+            Otherwise, the sync object is destroyed immediately.
+        </p>
+        <p>
+            If no errors are generated, <code class="constant">EGL_TRUE</code> is
+            returned, and <em class="parameter"><code>sync</code></em> will no longer be the
+            handle of a valid sync object.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            On failure, <code class="function">eglDestroySync</code> returns
+            <code class="constant">EGL_FALSE</code>.
+        </p>
+        <p>
+            If <em class="parameter"><code>sync</code></em> is not a valid sync object for
+            <em class="parameter"><code>display</code></em>, <code class="constant">EGL_FALSE</code>
+            is returned and an <code class="constant">EGL_BAD_PARAMETER</code> error
+            is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>display</code></em> does not match the display
+            passed to <code class="function">eglCreateSync</code> when
+            <em class="parameter"><code>sync</code></em> was created, the behaviour is
+            undefined.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            <code class="function">eglDestroySync</code> is available only if the EGL
+            version is 1.5 or greater.
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglClientWaitSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglClientWaitSync</span></span></a>,
+            <a class="citerefentry" href="eglCreateSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateSync</span></span></a>,
+            <a class="citerefentry" href="eglWaitSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitSync</span></span></a>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglGetConfigAttrib.xhtml
+++ b/sdk/docs/man/html/eglGetConfigAttrib.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetConfigAttrib - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglGetConfigs.xhtml
+++ b/sdk/docs/man/html/eglGetConfigs.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetConfigs - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglGetCurrentContext.xhtml
+++ b/sdk/docs/man/html/eglGetCurrentContext.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetCurrentContext - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglGetCurrentDisplay.xhtml
+++ b/sdk/docs/man/html/eglGetCurrentDisplay.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetCurrentDisplay - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -38,6 +38,21 @@
             <abbr class="acronym">EGL</abbr> rendering context, as specified by
             <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>.
             If no context is current, <code class="constant">EGL_NO_DISPLAY</code> is returned.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            Passing <code class="constant">EGL_NO_DISPLAY</code> to any command
+            taking an <span class="type">EGLDisplay</span> parameter will generate either
+            an <code class="constant">EGL_BAD_DISPLAY</code> error if the EGL
+            implementation validates <span class="type">EGLDisplay</span> handles, or
+            undefined behavior as described at the end of section 3.1 of the
+            EGL 1.5 Specification. The only exception to this rule is that
+            <code class="function">eglQueryString</code> will accept an
+            <span class="type">EGLDisplay</span> parameter of
+            <code class="constant">EGL_NO_DISPLAY</code> when querying the client
+            extension string (see section 3.3 of the EGL 1.5 Specification).
         </p>
       </div>
       <div class="refsect1" id="seealso">

--- a/sdk/docs/man/html/eglGetDisplay.xhtml
+++ b/sdk/docs/man/html/eglGetDisplay.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetDisplay - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -57,6 +57,26 @@
             display <em class="parameter"><code>native_display</code></em>.
         </p>
         <p>
+            The behavior of <code class="function">eglGetDisplay</code> is similar to
+            that of
+            <a class="citerefentry" href="eglGetPlatformDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetPlatformDisplay</span></span></a>,
+            but is specified in terms of implementation-specific behavior
+            rather than platform-specific extensions. As for
+            <a class="citerefentry" href="eglGetPlatformDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetPlatformDisplay</span></span></a>,
+            EGL considers the returned <span class="type">EGLDisplay</span> as belonging
+            to the same platform as <em class="parameter"><code>display_id</code></em>.
+            However, the set of platforms to which
+            <em class="parameter"><code>display_id</code></em> is permitted to belong, as
+            well as the actual type of <em class="parameter"><code>display_id</code></em>,
+            are implementation-specific. If
+            <em class="parameter"><code>display_id</code></em> is
+            <code class="constant">EGL_DEFAULT_DISPLAY</code>, a <em class="firstterm">default
+            display</em> is returned. Multiple calls made to
+            <code class="function">eglGetDisplay</code> with the same
+            <em class="parameter"><code>display_id</code></em> will return the same
+            <span class="type">EGLDisplay</span> handle.
+        </p>
+        <p>
             If <em class="parameter"><code>display_id</code></em> is
             <code class="constant">EGL_DEFAULT_DISPLAY</code>, a default display connection is returned.
         </p>
@@ -73,7 +93,8 @@
       <div class="refsect1" id="seealso">
         <h2>See Also</h2>
         <p>
-            <a class="citerefentry" href="eglInitialize.xhtml"><span class="citerefentry"><span class="refentrytitle">eglInitialize</span></span></a>
+            <a class="citerefentry" href="eglInitialize.xhtml"><span class="citerefentry"><span class="refentrytitle">eglInitialize</span></span></a>,
+            <a class="citerefentry" href="eglGetPlatformDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetPlatformDisplay</span></span></a>
         </p>
       </div>
       <p>

--- a/sdk/docs/man/html/eglGetError.xhtml
+++ b/sdk/docs/man/html/eglGetError.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetError - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -36,6 +36,13 @@
             <code class="function">eglGetError</code> returns the error of the last
             called <abbr class="acronym">EGL</abbr> function in the current thread.
             Initially, the error is set to <code class="constant">EGL_SUCCESS</code>.
+        </p>
+        <p>
+            When an EGL function could potentially generate several
+            different errors (for example, when passed both a bad attribute
+            name, and a bad attribute value for a legal attribute name), the
+            implementation may choose to generate any one of the applicable
+            errors.
         </p>
         <p>
             The following errors are currently defined:

--- a/sdk/docs/man/html/eglGetPlatformDisplay.xhtml
+++ b/sdk/docs/man/html/eglGetPlatformDisplay.xhtml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetPlatformDisplay - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglGetPlatformDisplay">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglGetPlatformDisplay — 
+            return an <abbr class="acronym">EGL</abbr> display connection
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLDisplay <strong class="fsfunc">eglGetPlatformDisplay</strong>(</code>
+              </td>
+              <td>EGLenum <var class="pdparam">platform</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>void * <var class="pdparam">native_display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>const EGLAttrib * <var class="pdparam">attrib_list</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>platform</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        Specifies the native platform to obtain a display for.
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>native_display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        Specifies the native display to connect to.
+                    </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>attrib_list</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                        Specifies attributes of the display being obtained.
+                    </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglGetPlatformDisplay</code> obtains an
+            <abbr class="acronym">EGL</abbr> display connection for the specified
+            <em class="parameter"><code>platform</code></em> and
+            <em class="parameter"><code>native_display</code></em>.
+        </p>
+        <p>
+            Valid values for <em class="parameter"><code>platform</code></em> are defined by
+            EGL extensions, as are requirements for
+            <em class="parameter"><code>native_display</code></em>.
+            For example, an extension specification that defines support for
+            the X11 platform may require that
+            <em class="parameter"><code>native_display</code></em> be a pointer to an X11
+            Display, and an extension specification that defines support for
+            the Microsoft Windows platform may require that
+            <em class="parameter"><code>native_display</code></em> be a pointer to a Windows
+            Device Context.
+        </p>
+        <p>
+            Valid attributes are defined by EGL extensions.
+            All attributes in <em class="parameter"><code>attrib_list</code></em>,
+            including boolean attributes, are immediately followed by
+            the corresponding desired value.
+            The list is terminated with <code class="constant">EGL_NONE</code>.
+            If an attribute is not specified in
+            <em class="parameter"><code>attrib_list</code></em> but is required for the
+            specified <em class="parameter"><code>platform</code></em>, then a default value
+            is used (and the attribute is said to be specified implicitly).
+        </p>
+        <p>
+            Multiple calls made to
+            <code class="function">eglGetPlatformDisplay</code> with the same
+            parameters will return the same <span class="type">EGLDisplay</span> handle.
+        </p>
+        <p>
+            If <em class="parameter"><code>platform</code></em> is valid but no display
+            matching <em class="parameter"><code>native_display</code></em> is available,
+            then <code class="constant">EGL_NO_DISPLAY</code> is returned; no error
+            condition is raised in this case.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            <code class="function">eglGetPlatformDisplay</code> is supported only if
+            the EGL version is 1.5 or greater.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            <code class="function">eglGetPlatformDisplay</code> returns
+            <code class="constant">EGL_NO_DISPLAY</code> on failure.
+        </p>
+        <p>
+            An <code class="constant">EGL_BAD_PARAMETER</code> error is generated if
+            <em class="parameter"><code>platform</code></em> has an invalid value.
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglInitialize.xhtml"><span class="citerefentry"><span class="refentrytitle">eglInitialize</span></span></a>,
+            <a class="citerefentry" href="eglGetDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetDisplay</span></span></a>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglGetProcAddress.xhtml
+++ b/sdk/docs/man/html/eglGetProcAddress.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetProcAddress - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -53,39 +53,61 @@
         <h2>Description</h2>
         <p>
             <code class="function">eglGetProcAddress</code> returns the address of
-            the extension function named by <em class="parameter"><code>procname</code></em>.
-            <em class="parameter"><code>procname</code></em>
-            must be a null-terminated string. The pointer returned
-            should be cast to a function pointer type matching the extension
-            function's definition in that extension specification. A return value
+            the client API or EGL function named by
+            <em class="parameter"><code>procname</code></em>. <em class="parameter"><code>procname</code></em>
+            must be a null-terminated string. The pointer returned should be
+            cast to a function pointer matching the function's definition in
+            the corresponding API or extension specification. A return value
             of <code class="constant">NULL</code> indicates that the specific
-            function does not exist for the <abbr class="acronym">EGL</abbr> implementation.
+            function does not exist for the implementation.
         </p>
         <p>
             A non-<code class="constant">NULL</code> return value does not guarantee
-            that an extension function is actually supported at runtime. The client
-            must also query
-            <a class="citerefentry" href="glGetString.xhtml"><span class="citerefentry"><span class="refentrytitle">glGetString</span></span></a>(<code class="constant">GL_EXTENSIONS</code>) or
-            <a class="citerefentry" href="eglQueryString.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryString</span></span></a>(<em class="parameter"><code>display</code></em>,
-            <code class="constant">EGL_EXTENSIONS</code>) to determine if an
-            extension is supported by a particular context or display.
+            that an extension function is actually supported at runtime. The
+            client must also make a corresponding query, such as
+            <code class="function">glGetString</code>(<code class="constant">GL_EXTENSIONS</code>)
+            for OpenGL and OpenGL ES extensions;
+            <code class="function">vgGetString</code>(<code class="constant">VG_EXTENSIONS</code>)
+            for OpenVG extensions;
+            <code class="function">eglQueryString</code>(<em class="parameter"><code>display</code></em>,
+            <code class="constant">EGL_EXTENSIONS</code>); or query the EGL or client
+            API version for non-extension functions, to determine if a
+            function is supported by EGL or a specific client API context.
         </p>
         <p>
-            Function pointers returned by
+            Client API function pointers returned by
             <code class="function">eglGetProcAddress</code> are independent of the
-            display and the currently bound context and may be used by any context
-            which supports the extension.
+            display and the currently bound client API context, and may be
+            used by any client API context which supports the function.
         </p>
         <p>
             <code class="function">eglGetProcAddress</code> may be queried for all
-            <abbr class="acronym">GL</abbr> and <abbr class="acronym">EGL</abbr> extension functions.
+            EGL and client API functions supported by the implementation
+            (whether those functions are extensions or not, and whether they
+            are supported by the current client API context or not).
+        </p>
+        <p>
+            For functions that are queryable with
+            <code class="function">eglGetProcAddress</code>, implementations may
+            choose to also export those functions statically from the object
+            libraries implementing those functions. However, portable
+            clients cannot rely on this behavior.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            If the EGL version is not 1.5 or greater, only queries of EGL
+            and client API <span class="emphasis"><em>extension</em></span> functions will
+            succeed.
         </p>
       </div>
       <div class="refsect1" id="seealso">
         <h2>See Also</h2>
         <p>
-            <a class="citerefentry" href="glGetString.xhtml"><span class="citerefentry"><span class="refentrytitle">glGetString</span></span></a>,
+            <code class="function">glGetString</code>
             <a class="citerefentry" href="eglQueryString.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryString</span></span></a>    </p>
+        <code class="function">vgGetString</code>
       </div>
       <p>
     </p>

--- a/sdk/docs/man/html/eglGetSyncAttrib.xhtml
+++ b/sdk/docs/man/html/eglGetSyncAttrib.xhtml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglGetSyncAttrib - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglGetSyncAttrib">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglGetSyncAttrib — 
+            Return an attribute of a sync object
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLBoolean <strong class="fsfunc">eglGetSyncAttrib</strong>(</code>
+              </td>
+              <td>(EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLSync <var class="pdparam">sync</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLint <var class="pdparam">attribute</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLAttrib *<var class="pdparam">value</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the <abbr class="acronym">EGL</abbr> display connection.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>sync</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the sync object to query.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>flags</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the EGL sync object attribute to query.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>timeout</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Returns the requested attribute value.
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglGetSyncAttrib</code> is used to query
+            attributes of the sync object <em class="parameter"><code>sync</code></em>. Legal
+            values for <em class="parameter"><code>attribute</code></em> depend on the type
+            of sync object, as shown in table
+            <a class="xref" href="#tab-syncattr" title="Table 1.  Attributes accepted by eglGetSyncAttrib">Table 1, “
+                Attributes accepted by <code class="function">eglGetSyncAttrib</code>
+            ”</a>. Assuming no errors are
+            generated, <code class="constant">EGL_TRUE</code> is returned and the
+            value of the queried attribute is returned in
+            *<em class="parameter"><code>value</code></em>.
+        </p>
+        <div class="table" id="tab-syncattr">
+          <div class="table-title">Table 1. 
+                Attributes accepted by <code class="function">eglGetSyncAttrib</code>
+            </div>
+          <div class="table-contents">
+            <table style="border-collapse: collapse; border-top: 2px solid ; border-bottom: 2px solid ; border-left: 2px solid ; border-right: 2px solid ; ">
+              <colgroup>
+                <col/>
+                <col/>
+                <col/>
+              </colgroup>
+              <thead>
+                <tr>
+                  <th style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Attribute</th>
+                  <th style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Description</th>
+                  <th style="text-align: left; border-bottom: 2px solid ; ">Supported Sync Objects</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Attribute</td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Description</td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">Supported Sync Objects</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_SYNC_TYPE</code>
+                  </td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Type of the sync object</td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">All</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">
+                    <code class="constant">EGL_SYNC_STATUS</code>
+                  </td>
+                  <td style="text-align: left; border-right: 2px solid ; border-bottom: 2px solid ; ">Status of the sync object</td>
+                  <td style="text-align: left; border-bottom: 2px solid ; ">All</td>
+                </tr>
+                <tr>
+                  <td style="text-align: left; border-right: 2px solid ; ">
+                    <code class="constant">EGL_SYNC_CONDITION</code>
+                  </td>
+                  <td style="text-align: left; border-right: 2px solid ; ">Signaling condition</td>
+                  <td style="text-align: left; ">
+                            <code class="constant">EGL_SYNC_FENCE</code> or
+                            <code class="constant">EGL_SYNC_CL_EVENT</code>
+                        </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <br class="table-break"/>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            On failure, <code class="function">eglGetSyncAttrib</code> returns
+            <code class="constant">EGL_FALSE</code> and *<em class="parameter"><code>value</code></em>
+            is not modified.
+        </p>
+        <p>
+            If <em class="parameter"><code>sync</code></em> is not a valid sync object for
+            <em class="parameter"><code>display</code></em>, an
+            <code class="constant">EGL_BAD_PARAMETER</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>attribute</code></em> is not one of the attributes
+            in table <a class="xref" href="#tab-syncattr" title="Table 1.  Attributes accepted by eglGetSyncAttrib">Table 1, “
+                Attributes accepted by <code class="function">eglGetSyncAttrib</code>
+            ”</a>, an
+            <code class="constant">EGL_BAD_ATTRIBUTE</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>attribute</code></em> is not supported for the
+            type of sync object passed in <em class="parameter"><code>sync</code></em>, an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>display</code></em> does not match the display
+            passed to <code class="function">eglCreateSync</code> when
+            <em class="parameter"><code>sync</code></em> was created, behaviour is undefined.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            <code class="function">eglGetSyncAttrib</code> is available only if the
+            EGL version is 1.5 or greater.
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglCreateSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateSync</span></span></a>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/eglGetSyncAttrib.xhtml
+++ b/sdk/docs/man/html/eglGetSyncAttrib.xhtml
@@ -72,7 +72,7 @@
             <dt>
               <span class="term">
                 <em class="parameter">
-                  <code>flags</code>
+                  <code>attribute</code>
                 </em>
               </span>
             </dt>
@@ -84,7 +84,7 @@
             <dt>
               <span class="term">
                 <em class="parameter">
-                  <code>timeout</code>
+                  <code>value</code>
                 </em>
               </span>
             </dt>

--- a/sdk/docs/man/html/eglInitialize.xhtml
+++ b/sdk/docs/man/html/eglInitialize.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglInitialize - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglIntro.xhtml
+++ b/sdk/docs/man/html/eglIntro.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglIntro - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -24,28 +24,39 @@
             using a <em class="firstterm">client API</em> such as OpenGL ES
             (a 3D renderer for embedded systems), OpenGL (a functional
             superset of OpenGL ES for desktop systems), and OpenVG (a 2D
-            vector graphics renderer) together with a native window
-            system, such as Microsoft Windows or the X Window System.
+            vector graphics renderer) together with a
+            <em class="firstterm">platform</em>, such as Microsoft Windows or
+            the X Window System.
         </p>
         <p>
             Depending on its implementation EGL might be more or less
-            tightly integrated into the native window system. Most EGL
+            tightly integrated into the platform. Most EGL
             functions require an EGL display connection, which can be
             obtained by calling
-            <a class="citerefentry" href="eglGetDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetDisplay</span></span></a>
-            and passing in a native display handle or
-            <code class="constant">EGL_DEFAULT_DISPLAY</code>. To initialize and
+            <a class="citerefentry" href="eglGetPlatformDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetPlatformDisplay</span></span></a>
+            or
+            <a class="citerefentry" href="eglGetDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetDisplay</span></span></a>.
+            To initialize and
             query what EGL version is supported on the display
             connection, call
             <a class="citerefentry" href="eglInitialize.xhtml"><span class="citerefentry"><span class="refentrytitle">eglInitialize</span></span></a>.
         </p>
         <p>
-            Native window systems supporting EGL make a subset of their
+            The EGL specification does not define the set of platforms that
+            may be supported by an EGL implementation, nor does it specify
+            behavior specific to any platform. The set of supported
+            platforms and their behavior is defined by platform-specific
+            extensions. To detect if a particular platform is supported,
+            clients should query the <code class="constant">EGL_EXTENSIONS</code>
+            string of <code class="constant">EGL_NO_DISPLAY</code> using
+            <a class="citerefentry" href="eglQueryString.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryString</span></span></a>.
+        </p>
+        <p>
+            Platforms supporting EGL make a subset of their
             visuals (which may also referred to as pixel formats, frame
             buffer configurations, or other similar terms) available for
             client API rendering. Windows and pixmaps created with these
-            visuals may also be rendered into using the native window
-            system API.
+            visuals may also be rendered into using the platform APIs.
         </p>
         <p>
             An EGL <em class="firstterm">surface</em> extends a native
@@ -59,9 +70,9 @@
             EGL supports rendering into three types of surfaces:
             windows, pixmaps and pixel buffers (pbuffers). EGL window
             and pixmap surfaces are associated with corresponding
-            resources of the native window system. EGL pixel buffers are
-            EGL only resources, and do not accept rendering through the
-            native window system.
+            resources of the platform. EGL pixel buffers are
+            EGL-only resources, and do not accept rendering through the
+            platform APIs.
         </p>
         <p>
             To render using a client API into an EGL surface, you must
@@ -123,13 +134,13 @@
             is called with different arguments.
         </p>
         <p>
-            Both native and client API commands may be used to operate
-            on certain surfaces, however, the two command streams are
+            Both platform and client API commands may be used to operate
+            on certain surfaces. However, the two command streams are
             not synchronized. Synchronization can be explicitly
             specified using by calling
-            <a class="citerefentry" href="eglWaitCLient.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitCLient</span></span></a>,
+            <a class="citerefentry" href="eglWaitClient.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitClient</span></span></a>,
             <a class="citerefentry" href="eglWaitNative.xhtml"><span class="citerefentry"><span class="refentrytitle">eglWaitNative</span></span></a>,
-            and possibly by calling other native window system commands.
+            and possibly by calling other platform APIs.
         </p>
       </div>
       <div class="refsect1" id="examples">
@@ -185,11 +196,20 @@ int main(int argc, char ** argv)
 }
 </pre>
       </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            Prior to EGL 1.5, platforms were referred to as the
+            <em class="firstterm">native window system</em>, and
+            platform-specific queries and APIs were not available. Only a
+            single native window system was supported.
+        </p>
+      </div>
       <div class="refsect1" id="usingeglextensions">
         <h2>Using EGL Extensions</h2>
         <p>
             All supported EGL extensions will have a corresponding definition in
-            <code class="filename">egl.h</code> and a token in the extensions string returned
+            <code class="filename">egl.h</code> and a token in the extension strings returned
             by
             <a class="citerefentry" href="eglQueryString.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryString</span></span></a>.
         </p>
@@ -240,6 +260,7 @@ int main(int argc, char ** argv)
             <a class="citerefentry" href="eglDestroySurface.xhtml"><span class="citerefentry"><span class="refentrytitle">eglDestroySurface</span></span></a>,
             <a class="citerefentry" href="eglGetConfigs.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetConfigs</span></span></a>,
             <a class="citerefentry" href="eglGetDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetDisplay</span></span></a>,
+            <a class="citerefentry" href="eglGetPlatformDisplay.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetPlatformDisplay</span></span></a>,
             <a class="citerefentry" href="eglInitialize.xhtml"><span class="citerefentry"><span class="refentrytitle">eglInitialize</span></span></a>,
             <a class="citerefentry" href="eglMakeCurrent.xhtml"><span class="citerefentry"><span class="refentrytitle">eglMakeCurrent</span></span></a>,
             <a class="citerefentry" href="eglQueryString.xhtml"><span class="citerefentry"><span class="refentrytitle">eglQueryString</span></span></a>,

--- a/sdk/docs/man/html/eglMakeCurrent.xhtml
+++ b/sdk/docs/man/html/eglMakeCurrent.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglMakeCurrent - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -95,31 +95,113 @@
         <p>
             <code class="function">eglMakeCurrent</code> binds <em class="parameter"><code>context</code></em>
             to the current rendering thread and to the <em class="parameter"><code>draw</code></em>
-            and <em class="parameter"><code>read</code></em> surfaces. <em class="parameter"><code>draw</code></em>
-            is used for all GL operations except for any pixel data read back
+            and <em class="parameter"><code>read</code></em> surfaces.
+        </p>
+        <p>
+            For an OpenGL or OpenGL ES context, <em class="parameter"><code>draw</code></em>
+            is used for all operations except for any pixel data read back or copied
             (<a class="citerefentry" href="glReadPixels.xhtml"><span class="citerefentry"><span class="refentrytitle">glReadPixels</span></span></a>,
             <a class="citerefentry" href="glCopyTexImage2D.xhtml"><span class="citerefentry"><span class="refentrytitle">glCopyTexImage2D</span></span></a>, and
             <a class="citerefentry" href="glCopyTexSubImage2D.xhtml"><span class="citerefentry"><span class="refentrytitle">glCopyTexSubImage2D</span></span></a>),
             which is taken from the frame buffer values of
+            <em class="parameter"><code>read</code></em>. Note that the same
+            <span class="type">EGLSurface</span> may be specified for both draw and read.
+        </p>
+        <p>
+            For an OpenVG context, the same <span class="type">EGLSurface</span> must be
+            specified for both <em class="parameter"><code>draw</code></em> and
             <em class="parameter"><code>read</code></em>.
         </p>
         <p>
-            If the calling thread has already a current rendering context, that
-            context is flushed and marked as no longer current.
+            If the calling thread has already a current rendering context of
+            the same client API type as <em class="parameter"><code>context</code></em>, then
+            that context is flushed and marked as no longer current.
+            <em class="parameter"><code>context</code></em> is then made the current context
+            for the calling thread. For purposes of
+            <code class="function">eglMakeCurrent</code>, the client API type of all
+            OpenGL ES and OpenGL contexts is considered the same. In other
+            words, if any OpenGL ES context is currently bound and
+            <em class="parameter"><code>context</code></em> is an OpenGL context, or if any
+            OpenGL context is currently bound and
+            <em class="parameter"><code>context</code></em> is an OpenGL ES context, the
+            currently bound context will be made no longer current and
+            <em class="parameter"><code>context</code></em> will be made current.
         </p>
         <p>
-            The first time that <em class="parameter"><code>context</code></em> is made current,
-            the viewport and scissor dimensions are set to the size of the
-            <em class="parameter"><code>draw</code></em> surface. The viewport and
-            scissor are not modified when <em class="parameter"><code>context</code></em> is
-            subsequently made current.
+            OpenGL and OpenGL ES buffer mappings created by e.g.
+            <code class="function">glMapBuffer</code> are not affected by
+            <code class="function">eglMakeCurrent</code>; they persist whether the
+            context owning the buffer is current or not.
         </p>
         <p>
-            To release the current context without assigning a new one, call
-            <code class="function">eglMakeCurrent</code> with <em class="parameter"><code>draw</code></em>
-            and <em class="parameter"><code>read</code></em> set to
-            <code class="constant">EGL_NO_SURFACE</code> and <em class="parameter"><code>context</code></em>
-            set to <code class="constant">EGL_NO_CONTEXT</code>.
+            If <em class="parameter"><code>draw</code></em> is destroyed after
+            <code class="function">eglMakeCurrent</code> is called, then subsequent
+            rendering commands will be processed and the context state will
+            be updated, but the surface contents become undefined. If
+            <em class="parameter"><code>read</code></em> is destroyed after
+            <code class="function">eglMakeCurrent</code> then pixel values
+            <em class="parameter"><code>read</code></em> from the framebuffer (e.g., as
+            result of calling glReadPixels) are undefined. If a native
+            window or pixmap underlying the <em class="parameter"><code>draw</code></em> or
+            <em class="parameter"><code>read</code></em> surfaces is destroyed, rendering and
+            <em class="parameter"><code>read</code></em>back are handled as above.
+        </p>
+        <p>
+            To release the current context without assigning a new one, set
+            <em class="parameter"><code>context</code></em> to
+            <code class="constant">EGL_NO_CONTEXT</code> and set
+            <em class="parameter"><code>draw</code></em> and <em class="parameter"><code>read</code></em> to
+            <code class="constant">EGL_NO_SURFACE</code> . The currently bound
+            context for the client API specified by the current rendering
+            API is flushed and marked as no longer current, and there will
+            be no current context for that client API after
+            <code class="function">eglMakeCurrent</code> returns. This is the only
+            case in which <code class="function">eglMakeCurrent</code> respects the
+            current rendering API. In all other cases, the client API
+            affected is determined by <em class="parameter"><code>context</code></em>. This
+            is the only case where an uninitialized display may be passed to
+            <code class="function">eglMakeCurrent</code>.
+        </p>
+        <p>
+            If ctx is not <code class="constant">EGL_NO_CONTEXT</code>, then both
+            <em class="parameter"><code>draw</code></em> and <em class="parameter"><code>read</code></em> must
+            not be <code class="constant">EGL_NO_SURFACE</code> unless
+            <em class="parameter"><code>context</code></em> is a context which supports being
+            bound without read and draw surfaces. In this case the context
+            is made current without a default framebuffer. The meaning of
+            this is defined by the client API of the supporting context (see
+            chapter 4 of the OpenGL 3.0 Specification, and the
+            <code class="constant">GL_OES_surfaceless_context</code> OpenGL ES
+            extension.).
+        </p>
+        <p>
+            The first time a OpenGL or OpenGL ES context is made current the
+            viewport and scissor dimensions are set to the size of the
+            <em class="parameter"><code>draw</code></em> surface (as though
+            <code class="function">glViewport</code>(0,0,w,h) and
+            <code class="function">glScissor</code>(0,0,<em class="parameter"><code>w</code></em>,<em class="parameter"><code>h</code></em>)
+            were called, where <em class="parameter"><code>w</code></em> and
+            <em class="parameter"><code>h</code></em> are the width and height of the
+            surface, respectively). However, the viewport and scissor
+            dimensions are not modified when <em class="parameter"><code>context</code></em>
+            is subsequently made current. The client is responsible for
+            resetting the viewport and scissor in this case.
+        </p>
+        <p>
+            The first time <em class="parameter"><code>context</code></em> is made current,
+            if it is without a default framebuffer (e.g. both
+            <em class="parameter"><code>draw</code></em> and <em class="parameter"><code>read</code></em> are
+            <code class="constant">EGL_NO_SURFACE</code> ), then the viewport and
+            scissor regions are set as though
+            <code class="function">glViewport</code>(0,0,0,0) and
+            <code class="function">glScissor</code>(0,0,0,0) were called.
+        </p>
+        <p>
+            Implementations may delay allocation of auxiliary buffers for a
+            surface until they are required by a context (which may result
+            in the <code class="constant">EGL_BAD_ALLOC</code> error described
+            above). Once allocated, however, auxiliary buffers and their
+            contents persist until a surface is deleted.
         </p>
         <p>
             Use
@@ -132,81 +214,130 @@
       <div class="refsect1" id="errors">
         <h2>Errors</h2>
         <p>
-            <code class="constant">EGL_FALSE</code> is returned on failure,
-            <code class="constant">EGL_TRUE</code> otherwise. If <code class="constant">EGL_FALSE</code>
-            is returned, the previously current rendering context and
-            surfaces (if any) remain unchanged.
+            If <em class="parameter"><code>draw</code></em> or <em class="parameter"><code>read</code></em>
+            are not compatible with <em class="parameter"><code>context</code></em>, then an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_DISPLAY</code> is generated if
-            <em class="parameter"><code>display</code></em> is not an EGL display connection.
+            If <em class="parameter"><code>context</code></em> is current to some other
+            thread, or if either <em class="parameter"><code>draw</code></em> or
+            <em class="parameter"><code>read</code></em> are bound to contexts in another
+            thread, an <code class="constant">EGL_BAD_ACCESS</code> error is
+            generated.
         </p>
         <p>
-            <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
-            <em class="parameter"><code>display</code></em> has not been initialized.
+            If binding <em class="parameter"><code>context</code></em> would exceed the
+            number of current contexts of that client API type supported by
+            the implementation, an <code class="constant">EGL_BAD_ACCESS</code> error
+            is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_SURFACE</code> is generated if
-            <em class="parameter"><code>draw</code></em> or <em class="parameter"><code>read</code></em> is not an
-            EGL surface.
+            If either <em class="parameter"><code>draw</code></em> or
+            <em class="parameter"><code>read</code></em> are pbuffers created with
+            <code class="function">eglCreatePbufferFromClientBuffer</code>, and the
+            underlying bound client API buffers are in use by the client API
+            that created them, an <code class="constant">EGL_BAD_ACCESS</code> error
+            is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_CONTEXT</code> is generated if
-            <em class="parameter"><code>context</code></em> is not an EGL rendering context.
+            If <em class="parameter"><code>context</code></em> is not a valid context and is
+            not <code class="constant">EGL_NO_CONTEXT</code>, an
+            <code class="constant">EGL_BAD_CONTEXT</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_MATCH</code> is generated if
-            <em class="parameter"><code>draw</code></em> or
-            <em class="parameter"><code>read</code></em>
-            are not compatible with
-            <em class="parameter"><code>context</code></em>, or if
-            <em class="parameter"><code>context</code></em> is set to
-            <code class="constant">EGL_NO_CONTEXT</code> and
-            <em class="parameter"><code>draw</code></em> or
-            <em class="parameter"><code>read</code></em>
-            are not set to
-            <code class="constant">EGL_NO_SURFACE</code>, or if
-            <em class="parameter"><code>draw</code></em> or
-            <em class="parameter"><code>read</code></em> are set to
-            <code class="constant">EGL_NO_SURFACE</code> and
-            <em class="parameter"><code>context</code></em> is not set to
-            <code class="constant">EGL_NO_CONTEXT</code>.
+            If either <em class="parameter"><code>draw</code></em> or
+            <em class="parameter"><code>read</code></em> are not valid EGL surfaces and are
+            not <code class="constant">EGL_NO_SURFACE</code>, an
+            <code class="constant">EGL_BAD_SURFACE</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_ACCESS</code> is generated if
-            <em class="parameter"><code>context</code></em>
-            is current to some other thread.
+            If <em class="parameter"><code>context</code></em> is
+            <code class="constant">EGL_NO_CONTEXT</code> and either
+            <em class="parameter"><code>draw</code></em> or <em class="parameter"><code>read</code></em> are
+            not <code class="constant">EGL_NO_SURFACE</code>, an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_NATIVE_PIXMAP</code> may be generated if
-            a native pixmap underlying either
-            <em class="parameter"><code>draw</code></em> or
-            <em class="parameter"><code>read</code></em>
-            is no longer valid.
+            If either of <em class="parameter"><code>draw</code></em> or
+            <em class="parameter"><code>read</code></em> is a valid surface and the other is
+            <code class="constant">EGL_NO_SURFACE</code>, an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_NATIVE_WINDOW</code> may be generated if
-            a native window underlying either
-            <em class="parameter"><code>draw</code></em> or
-            <em class="parameter"><code>read</code></em>
-            is no longer valid.
+            If <em class="parameter"><code>context</code></em> does not support being bound
+            without <em class="parameter"><code>read</code></em> and
+            <em class="parameter"><code>draw</code></em> surfaces, and both
+            <em class="parameter"><code>draw</code></em> and <em class="parameter"><code>read</code></em> are
+            <code class="constant">EGL_NO_SURFACE</code>, an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_CURRENT_SURFACE</code> is generated if
-            the previous context has unflushed commands and the previous surface
-            is no longer valid.
+            If a native window underlying either <em class="parameter"><code>draw</code></em>
+            or <em class="parameter"><code>read</code></em> is no longer valid, an
+            <code class="constant">EGL_BAD_NATIVE_WINDOW</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_BAD_ALLOC</code> may be generated if
-            allocation of ancillary buffers for <em class="parameter"><code>draw</code></em> or
-            <em class="parameter"><code>read</code></em> were delayed until
-            <code class="function">eglMakeCurrent</code> is called, and there are not
-            enough resources to allocate them.
+            If <em class="parameter"><code>draw</code></em> and <em class="parameter"><code>read</code></em>
+            cannot fit into graphics memory simultaneously, an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
         </p>
         <p>
-            <code class="constant">EGL_CONTEXT_LOST</code> is generated if a power management
-            event has occurred. The application must destroy all contexts and
-            reinitialise OpenGL ES state and objects to continue rendering.
+            If the previous context of the calling thread has unflushed
+            commands, and the previous surface is no longer valid, an
+            <code class="constant">EGL_BAD_CURRENT_SURFACE</code> error is generated.
+        </p>
+        <p>
+            If the ancillary buffers for <em class="parameter"><code>draw</code></em> and
+            <em class="parameter"><code>read</code></em> cannot be allocated, an
+            <code class="constant">EGL_BAD_ALLOC</code> error is generated.
+        </p>
+        <p>
+            If a power management event has occurred, an
+            <code class="constant">EGL_CONTEXT_LOST</code> error is generated.
+        </p>
+        <p>
+            If any of the following are true:
+
+            </p>
+        <div class="itemizedlist">
+          <ul class="itemizedlist" style="list-style-type: disc; ">
+            <li class="listitem">
+              <p>
+                    <em class="parameter"><code>context</code></em> is not
+                    <code class="constant">EGL_NO_CONTEXT</code>
+                </p>
+            </li>
+            <li class="listitem">
+              <p>
+                    <em class="parameter"><code>read</code></em> is not
+                    <code class="constant">EGL_NO_SURFACE</code>
+                </p>
+            </li>
+            <li class="listitem">
+              <p>
+                    <em class="parameter"><code>draw</code></em> is not
+                    <code class="constant">EGL_NO_SURFACE</code>
+                </p>
+            </li>
+          </ul>
+        </div>
+        <p>
+
+            then an <code class="constant">EGL_NOT_INITIALIZED</code> error is
+            generated if <em class="parameter"><code>display</code></em> is a valid but
+            uninitialized display.
+        </p>
+        <p>
+            As with other commands taking <span class="type">EGLDisplay</span>
+            parameters, if <em class="parameter"><code>display</code></em> is not a valid
+            <span class="type">EGLDisplay</span> handle, an
+            <code class="constant">EGL_BAD_DISPLAY</code> error is generated. (Some
+            implementations have chosen to allow
+            <code class="constant">EGL_NO_DISPLAY</code> as a valid
+            <em class="parameter"><code>display</code></em> parameter for
+            <code class="function">eglMakeCurrent</code>. This behavior is not
+            portable to all EGL implementations, and should be considered as
+            an undocumented vendor extension).
         </p>
       </div>
       <div class="refsect1" id="seealso">

--- a/sdk/docs/man/html/eglQueryAPI.xhtml
+++ b/sdk/docs/man/html/eglQueryAPI.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglQueryAPI - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglQueryContext.xhtml
+++ b/sdk/docs/man/html/eglQueryContext.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglQueryContext - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglQueryString.xhtml
+++ b/sdk/docs/man/html/eglQueryString.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglQueryString - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -12,7 +12,8 @@
       <div class="refnamediv">
         <h2>Name</h2>
         <p>eglQueryString — 
-            return a string describing an <abbr class="acronym">EGL</abbr> display connection
+            return a string describing properties of the EGL client or of an
+            <abbr class="acronym">EGL</abbr> display connection
         </p>
       </div>
       <div class="refsynopsisdiv">
@@ -72,8 +73,9 @@
         <h2>Description</h2>
         <p>
             <code class="function">eglQueryString</code> returns a pointer to a
-            static string describing an EGL display connection.
-            <em class="parameter"><code>name</code></em> can be one of the following:
+            static, zero-terminated string describing properties of the EGL
+            client or of an EGL display connection.
+            <em class="parameter"><code>name</code></em> may be one of the following:
         </p>
         <div class="variablelist">
           <dl class="variablelist">
@@ -86,7 +88,7 @@
               <p>
                     Returns a string describing which client rendering
                     APIs are supported. The string contains a
-                    space-separate list of API names. The list must
+                    space-separated list of API names. The list must
                     include at least one of <code class="code">OpenGL</code>,
                     <code class="code">OpenGL_ES</code>, or <code class="code">OpenVG</code>.
                     These strings correspond respectively to values
@@ -104,8 +106,9 @@
             </dt>
             <dd>
               <p>
-                    Returns the company responsible for this EGL implementation. This
-                    name does not change from release to release.
+                    Returns the name of the vendor responsible for this EGL
+                    implementation. The format and contents of the string
+                    are implementation-dependent.
                 </p>
             </dd>
             <dt>
@@ -115,14 +118,27 @@
             </dt>
             <dd>
               <p>
-                    Returns a version or release number.
-                    The <code class="constant">EGL_VERSION</code> string is laid out as
-                    follows:</p>
+                        Returns a version or release number. The
+                        <code class="constant">EGL_VERSION</code> string is laid out
+                        as follows:
+                    </p>
               <p>
-                    <em class="replaceable"><code>major_version</code></em>.<em class="replaceable"><code>minor_version</code></em>
-                    space
-                    <em class="replaceable"><code>vendor_specific_info</code></em>
-                </p>
+                        <em class="replaceable"><code>major_version</code></em>.<em class="replaceable"><code>minor_version</code></em>
+                        space
+                        <em class="replaceable"><code>vendor_specific_info</code></em>
+                    </p>
+              <p>
+                        Both the major and minor portions of the version
+                        number are numeric. Their values must match the
+                        <em class="parameter"><code>major</code></em> and
+                        <em class="parameter"><code>minor</code></em> values returned by
+                        <a class="citerefentry" href="eglInitialize.xhtml"><span class="citerefentry"><span class="refentrytitle">eglInitialize</span></span></a>.
+                    </p>
+              <p>
+                        The vendor-specific information is optional; if
+                        present, its format and contents are
+                        implementation-specific.
+                    </p>
             </dd>
             <dt>
               <span class="term">
@@ -131,8 +147,24 @@
             </dt>
             <dd>
               <p>
-                    Returns a space separated list of supported extensions to EGL.
-                </p>
+                        Returns a space separated list of supported
+                        extensions to EGL. If there are no extensions, then
+                        the empty string is returned.
+                    </p>
+              <p>
+                        If <em class="parameter"><code>display</code></em> is
+                        <code class="constant">EGL_NO_DISPLAY</code>, then the
+                        <code class="constant">EGL_EXTENSIONS</code> string describes
+                        the set of supported <em class="firstterm">client
+                        extensions</em>. If
+                        <em class="parameter"><code>display</code></em> is a valid,
+                        initialized display, then the
+                        <code class="constant">EGL_EXTENSIONS</code> string describes
+                        the set of <em class="firstterm">display extensions</em>
+                        supported by that display. The set of supported
+                        client extensions is disjoint from the set of
+                        extensions supported by any given display.
+                    </p>
             </dd>
           </dl>
         </div>
@@ -143,6 +175,11 @@
             <code class="constant">EGL_CLIENT_APIS</code> is supported only if
             the EGL version is 1.2 or greater.
         </p>
+        <p>
+            A <em class="parameter"><code>display</code></em> of
+            <code class="constant">EGL_NO_DISPLAY</code> is supported only if the EGL
+            version is 1.5 or greater.
+        </p>
       </div>
       <div class="refsect1" id="errors">
         <h2>Errors</h2>
@@ -151,11 +188,16 @@
         </p>
         <p>
             <code class="constant">EGL_BAD_DISPLAY</code> is generated if
-            <em class="parameter"><code>display</code></em> is not an EGL display connection.
+            <em class="parameter"><code>display</code></em> is not an EGL display connection,
+            unless <em class="parameter"><code>display</code></em> is
+            <code class="constant">EGL_NO_DISPLAY</code> and
+            <em class="parameter"><code>name</code></em> is
+            <code class="constant">EGL_EXTENSIONS</code>.
         </p>
         <p>
             <code class="constant">EGL_NOT_INITIALIZED</code> is generated if
-            <em class="parameter"><code>display</code></em> has not been initialized.
+            <em class="parameter"><code>display</code></em> is a valid but uninitialized
+            EGLDisplay.
         </p>
         <p>
             <code class="constant">EGL_BAD_PARAMETER</code> is generated if

--- a/sdk/docs/man/html/eglQuerySurface.xhtml
+++ b/sdk/docs/man/html/eglQuerySurface.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglQuerySurface - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -115,6 +115,19 @@
               <p>
                     Returns the ID of the EGL frame buffer configuration
                     with respect to which the surface was created.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_GL_COLORSPACE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Returns the color space used by OpenGL and OpenGL ES
+                    when rendering to the surface, either
+                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code> or
+                    <code class="constant">EGL_GL_COLORSPACE_LINEAR</code>.
                 </p>
             </dd>
             <dt>
@@ -283,6 +296,32 @@
             </dd>
             <dt>
               <span class="term">
+                <code class="constant">EGL_VG_ALPHA_FORMAT</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Returns the interpretation of alpha values used by
+                    OpenVG when rendering to the surface, either
+                    <code class="constant">EGL_VG_ALPHA_FORMAT_NONPRE</code> or
+                    <code class="constant">EGL_VG_ALPHA_FORMAT_PRE</code>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <code class="constant">EGL_VG_COLORSPACE</code>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Returns the color space used by OpenVG when rendering to
+                    the surface, either
+                    <code class="constant">EGL_VG_COLORSPACE_sRGB</code> or
+                    <code class="constant">EGL_VG_COLORSPACE_LINEAR</code>.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
                 <code class="constant">EGL_WIDTH</code>
               </span>
             </dt>
@@ -296,6 +335,10 @@
       </div>
       <div class="refsect1" id="notes">
         <h2>Notes</h2>
+        <p>
+            Attribute <code class="constant">EGL_GL_COLORSPACE</code> is supported
+            only if the EGL version is 1.5 or greater.
+        </p>
         <p>
             Attribute <code class="constant">EGL_MULTISAMPLE_RESOLVE</code> is
             supported only if the EGL version is 1.4 or greater.

--- a/sdk/docs/man/html/eglReleaseTexImage.xhtml
+++ b/sdk/docs/man/html/eglReleaseTexImage.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglReleaseTexImage - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglReleaseThread.xhtml
+++ b/sdk/docs/man/html/eglReleaseThread.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglReleaseThread - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglSurfaceAttrib.xhtml
+++ b/sdk/docs/man/html/eglSurfaceAttrib.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglSurfaceAttrib - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglSwapBuffers.xhtml
+++ b/sdk/docs/man/html/eglSwapBuffers.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglSwapBuffers - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>
@@ -67,21 +67,27 @@
       <div class="refsect1" id="description">
         <h2>Description</h2>
         <p>
-            If <em class="parameter"><code>surface</code></em> is a window surface,
-            <code class="function">eglSwapBuffers</code> posts its color buffer
-            to the associated native window.
+            If <em class="parameter"><code>surface</code></em> is a back-buffered window
+            surface, <code class="function">eglSwapBuffers</code> then the color
+            buffer is copied (posted) native window associated with that
+            surface. If <em class="parameter"><code>surface</code></em> is a single-buffered
+            window, pixmap, or pixel buffer surface,
+            <code class="function">eglSwapBuffers</code> has no effect.
         </p>
         <p>
             The contents of ancillary buffers are always undefined after
-            calling <code class="function">eglSwapBuffers</code>. The contents of
-            the color buffer are left unchanged if the value of the
+            calling <code class="function">eglSwapBuffers</code>. The contents of the
+            color buffer are undefined if the value of the
             <code class="constant">EGL_SWAP_BEHAVIOR</code> attribute of
-            <em class="parameter"><code>surface</code></em> is
-            <code class="constant">EGL_BUFFER_PRESERVED</code>, and are undefined
-            if the value is <code class="constant">EGL_BUFFER_DESTROYED</code>.
-            The value of <code class="constant">EGL_SWAP_BEHAVIOR</code> can be
-            set for some surfaces using
+            <em class="parameter"><code>surface</code></em> is not
+            <code class="constant">EGL_BUFFER_PRESERVED</code>. The value of
+            <code class="constant">EGL_SWAP_BEHAVIOR</code> can be set for some
+            surfaces using
             <a class="citerefentry" href="eglSurfaceAttrib.xhtml"><span class="citerefentry"><span class="refentrytitle">eglSurfaceAttrib</span></span></a>.
+            <code class="constant">EGL_SWAP_BEHAVIOR</code> applies only to the color
+            buffer. EGL has no way to specify or query whether or not
+            ancillary buffers are preserved, and applications should not
+            rely on this behavior.
         </p>
         <p>
             <code class="function">eglSwapBuffers</code> performs an implicit
@@ -94,33 +100,44 @@
             <code class="function">eglSwapBuffers</code>, but are not executed
             until the buffer exchange is completed.
         </p>
+      </div>
+      <div class="refsect1" id="resize">
+        <h2>Native Window Resizing</h2>
         <p>
-            If <em class="parameter"><code>surface</code></em> is a pixel buffer or a pixmap,
-            <code class="function">eglSwapBuffers</code>
-            has no effect, and no error is generated.
+            If the native window corresponding to
+            <em class="parameter"><code>surface</code></em> has been resized prior to the
+            swap, <em class="parameter"><code>surface</code></em> must be resized to match.
+            <em class="parameter"><code>surface</code></em> will normally be resized by the
+            EGL implementation at the time the native window is resized. If
+            the implementation cannot do this transparently to the client,
+            then <code class="function">eglSwapBuffers</code> must detect the change
+            and resize surface prior to copying its pixels to the native
+            window. If <em class="parameter"><code>surface</code></em> shrinks as a result of
+            resizing, some rendered pixels are lost. If
+            <em class="parameter"><code>surface</code></em> grows, the newly allocated buffer
+            contents are undefined. The resizing behavior described here
+            only maintains consistency of EGL surfaces and native windows;
+            clients are still responsible for detecting window size changes
+            (using platform-specific means) and changing their viewport and
+            scissor regions accordingly.
         </p>
       </div>
       <div class="refsect1" id="notes">
         <h2>Notes</h2>
         <p>
-            Attribute <code class="constant">EGL_SWAP_BEHAVIOR</code> is
-            supported only if the EGL version is 1.2 or greater. In
-            earlier versions, behavior is as though the attribute
-            exists, and always has the value
-            <code class="constant">EGL_BUFFER_DESTROYED</code>.
+            Attribute <code class="constant">EGL_SWAP_BEHAVIOR</code> is supported
+            only if the EGL version is 1.2 or greater. In earlier versions,
+            behavior is as though the attribute exists, and always has the
+            value <code class="constant">EGL_BUFFER_DESTROYED</code>.
         </p>
         <p>
             The EGL 1.4 specification was updated to acknowledge that
-            ancillary buffers are not necessarily preserved after a
-            swap, and that the <code class="constant">EGL_SWAP_BEHAVIOR</code>
-            attribute applies only to the color buffer. This change in
-            the specification acknowledged the behavior of many shipping
+            ancillary buffers are not necessarily preserved after a swap,
+            and that the <code class="constant">EGL_SWAP_BEHAVIOR</code> attribute
+            applies only to the color buffer. This change in the
+            specification acknowledged the behavior of many shipping
             implementations, and is not intended to result in behavior
-            changes in any existing implementation. Applications which
-            require preservation of ancillary buffers across a swap
-            should be aware that not all implementations can preserve
-            them, and that EGL 1.4 has no way to query whether or not
-            they are preserved.
+            changes in any existing implementation.
         </p>
       </div>
       <div class="refsect1" id="errors">
@@ -150,8 +167,9 @@
       <div class="refsect1" id="seealso">
         <h2>See Also</h2>
         <p>
-            <a class="citerefentry" href="glFlush.xhtml"><span class="citerefentry"><span class="refentrytitle">glFlush</span></span></a>,
-            <a class="citerefentry" href="eglCopyBuffers.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCopyBuffers</span></span></a>
+            <code class="function">glFlush</code>,
+            <a class="citerefentry" href="eglCopyBuffers.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCopyBuffers</span></span></a>,
+            <code class="function">vgFlush</code>
         </p>
       </div>
       <p>

--- a/sdk/docs/man/html/eglSwapInterval.xhtml
+++ b/sdk/docs/man/html/eglSwapInterval.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglSwapInterval - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglTerminate.xhtml
+++ b/sdk/docs/man/html/eglTerminate.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglTerminate - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglWaitClient.xhtml
+++ b/sdk/docs/man/html/eglWaitClient.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglWaitClient - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglWaitGL.xhtml
+++ b/sdk/docs/man/html/eglWaitGL.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglWaitGL - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglWaitNative.xhtml
+++ b/sdk/docs/man/html/eglWaitNative.xhtml
@@ -3,7 +3,7 @@
   <head>
     <title xmlns:xlink="http://www.w3.org/1999/xlink">eglWaitNative - EGL Reference Pages</title>
     <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
   </head>
   <body>
     <header/>

--- a/sdk/docs/man/html/eglWaitSync.xhtml
+++ b/sdk/docs/man/html/eglWaitSync.xhtml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title xmlns:xlink="http://www.w3.org/1999/xlink">eglWaitSync - EGL Reference Pages</title>
+    <link rel="stylesheet" type="text/css" href="khronos-man.css"/>
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1"/>
+  </head>
+  <body>
+    <header/>
+    <div class="refentry" id="eglWaitSync">
+      <div class="titlepage"/>
+      <div class="refnamediv">
+        <h2>Name</h2>
+        <p>eglWaitSync — 
+            Wait in the server for a sync object to be signalled
+        </p>
+      </div>
+      <div class="refsynopsisdiv">
+        <h2>C Specification</h2>
+        <div class="funcsynopsis">
+          <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
+            <tr>
+              <td>
+                <code class="funcdef">EGLBoolean <strong class="fsfunc">eglWaitSync</strong>(</code>
+              </td>
+              <td>(EGLDisplay <var class="pdparam">display</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLSync <var class="pdparam">sync</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
+              <td>EGLint <var class="pdparam">flags</var><code>)</code>;</td>
+            </tr>
+          </table>
+          <div class="funcprototype-spacer"> </div>
+        </div>
+      </div>
+      <div class="refsect1" id="parameters">
+        <h2>Parameters</h2>
+        <div class="variablelist">
+          <dl class="variablelist">
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>display</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the <abbr class="acronym">EGL</abbr> display connection.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>sync</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies the sync object to wait on.
+                </p>
+            </dd>
+            <dt>
+              <span class="term">
+                <em class="parameter">
+                  <code>flags</code>
+                </em>
+              </span>
+            </dt>
+            <dd>
+              <p>
+                    Specifies flags controlling wait behavior.
+                </p>
+            </dd>
+          </dl>
+        </div>
+      </div>
+      <div class="refsect1" id="description">
+        <h2>Description</h2>
+        <p>
+            <code class="function">eglWaitSync</code> is similar to
+            <code class="function">eglClientWaitSync</code>, but instead of blocking
+            and not returning to the application until
+            <em class="parameter"><code>sync</code></em> is signaled,
+            <code class="function">eglWaitSync</code> returns immediately. On
+            success, <code class="constant">EGL_TRUE</code> is returned, and the
+            server for the client API context will block until
+            <em class="parameter"><code>sync</code></em> is signaled.
+        </p>
+        <p>
+            Note: <code class="function">eglWaitSync</code> allows applications to
+            continue to queue commands from the application in anticipation
+            of the sync being signaled, potentially increasing parallelism
+            between application, client API server code, and the GPU. The
+            server only blocks execution of commands for the specific
+            context on which <code class="function">eglWaitSync</code> was issued;
+            other contexts implemented by the same server are not affected..
+        </p>
+        <p>
+            <em class="parameter"><code>sync</code></em> has the same meaning as for
+            <code class="function">eglClientWaitSync</code>.
+        </p>
+        <p>
+            <em class="parameter"><code>flags</code></em> must be 0.
+        </p>
+        <p>
+            <code class="function">eglWaitSync</code> requires support from the bound
+            client API, and will not succeed unless the same client API
+            properties described for creation of fence syncs in
+            <a class="citerefentry" href="eglCreateSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateSync</span></span></a>
+            are satisfied.
+        </p>
+      </div>
+      <div class="refsect1" id="errors">
+        <h2>Errors</h2>
+        <p>
+            <code class="function">eglWaitSync</code> returns
+            <code class="constant">EGL_FALSE</code> on failure, and does not cause
+            the server for the client API context to block.
+        </p>
+        <p>
+            If the current context for the currently bound client API does
+            not support server waits, an <code class="constant">EGL_BAD_MATCH</code>
+            error is generated.
+        </p>
+        <p>
+            If no context is current for the currently bound client API
+            (i.e., <code class="function">eglGetCurrentContext</code> returns
+            <code class="constant">EGL_NO_CONTEXT</code>), an
+            <code class="constant">EGL_BAD_MATCH</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>display</code></em> does not match the
+            <span class="type">EGLDisplay</span> passed to
+            <code class="function">eglCreateSync</code> when
+            <em class="parameter"><code>sync</code></em> was created, the behavior is
+            undefined.
+        </p>
+        <p>
+            If <em class="parameter"><code>sync</code></em> is not a valid sync object for
+            <em class="parameter"><code>display</code></em>, an
+            <code class="constant">EGL_BAD_PARAMETER</code> error is generated.
+        </p>
+        <p>
+            If <em class="parameter"><code>flags</code></em> is not 0, an
+            <code class="constant">EGL_BAD_PARAMETER</code> error is generated.
+        </p>
+      </div>
+      <div class="refsect1" id="notes">
+        <h2>Notes</h2>
+        <p>
+            <code class="function">eglWaitSync</code> is available only if the EGL
+            version is 1.5 or greater.
+        </p>
+      </div>
+      <div class="refsect1" id="seealso">
+        <h2>See Also</h2>
+        <p>
+            <a class="citerefentry" href="eglClientWaitSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglClientWaitSync</span></span></a>,
+            <a class="citerefentry" href="eglCreateSync.xhtml"><span class="citerefentry"><span class="refentrytitle">eglCreateSync</span></span></a>,
+            <a class="citerefentry" href="eglGetCurrentContext.xhtml"><span class="citerefentry"><span class="refentrytitle">eglGetCurrentContext</span></span></a>
+        </p>
+      </div>
+      <p>
+    </p>
+      <div class="refsect3" id="copyright">
+        <img src="KhronosLogo.jpg"/>
+        <p>
+            Copyright © 2003-2014 The Khronos Group Inc.
+            Permission is hereby granted, free of charge, to any person obtaining a
+            copy of this software and/or associated documentation files (the
+            "Materials"), to deal in the Materials without restriction, including
+            without limitation the rights to use, copy, modify, merge, publish,
+            distribute, sublicense, and/or sell copies of the Materials, and to
+            permit persons to whom the Materials are furnished to do so, subject to
+            the condition that this copyright notice and permission notice shall be included
+            in all copies or substantial portions of the Materials.
+        </p>
+      </div>
+      <p>
+</p>
+    </div>
+    <footer/>
+  </body>
+</html>

--- a/sdk/docs/man/html/index.php
+++ b/sdk/docs/man/html/index.php
@@ -31,6 +31,7 @@
                 <li><a href="eglCreatePbufferFromClientBuffer.xhtml" target="pagedisplay">eglCreatePbufferFromClientBuffer</a></li>
                 <li><a href="eglCreatePbufferSurface.xhtml" target="pagedisplay">eglCreatePbufferSurface</a></li>
                 <li><a href="eglCreatePixmapSurface.xhtml" target="pagedisplay">eglCreatePixmapSurface</a></li>
+                <li><a href="eglCreatePlatformPixmapSurface.xhtml" target="pagedisplay">eglCreatePlatformPixmapSurface</a></li>
                 <li><a href="eglCreatePlatformWindowSurface.xhtml" target="pagedisplay">eglCreatePlatformWindowSurface</a></li>
                 <li><a href="eglCreateSync.xhtml" target="pagedisplay">eglCreateSync</a></li>
                 <li><a href="eglCreateWindowSurface.xhtml" target="pagedisplay">eglCreateWindowSurface</a></li>

--- a/sdk/docs/man/html/index.php
+++ b/sdk/docs/man/html/index.php
@@ -31,6 +31,7 @@
                 <li><a href="eglCreatePbufferFromClientBuffer.xhtml" target="pagedisplay">eglCreatePbufferFromClientBuffer</a></li>
                 <li><a href="eglCreatePbufferSurface.xhtml" target="pagedisplay">eglCreatePbufferSurface</a></li>
                 <li><a href="eglCreatePixmapSurface.xhtml" target="pagedisplay">eglCreatePixmapSurface</a></li>
+                <li><a href="eglCreatePlatformWindowSurface.xhtml" target="pagedisplay">eglCreatePlatformWindowSurface</a></li>
                 <li><a href="eglCreateSync.xhtml" target="pagedisplay">eglCreateSync</a></li>
                 <li><a href="eglCreateWindowSurface.xhtml" target="pagedisplay">eglCreateWindowSurface</a></li>
             </ul> <!-- End Level3 -->

--- a/sdk/docs/man/html/index.php
+++ b/sdk/docs/man/html/index.php
@@ -24,11 +24,14 @@
         <li>c
             <ul class="Level3">
                 <li><a href="eglChooseConfig.xhtml" target="pagedisplay">eglChooseConfig</a></li>
+                <li><a href="eglClientWaitSync.xhtml" target="pagedisplay">eglClientWaitSync</a></li>
                 <li><a href="eglCopyBuffers.xhtml" target="pagedisplay">eglCopyBuffers</a></li>
                 <li><a href="eglCreateContext.xhtml" target="pagedisplay">eglCreateContext</a></li>
+                <li><a href="eglCreateImage.xhtml" target="pagedisplay">eglCreateImage</a></li>
                 <li><a href="eglCreatePbufferFromClientBuffer.xhtml" target="pagedisplay">eglCreatePbufferFromClientBuffer</a></li>
                 <li><a href="eglCreatePbufferSurface.xhtml" target="pagedisplay">eglCreatePbufferSurface</a></li>
                 <li><a href="eglCreatePixmapSurface.xhtml" target="pagedisplay">eglCreatePixmapSurface</a></li>
+                <li><a href="eglCreateSync.xhtml" target="pagedisplay">eglCreateSync</a></li>
                 <li><a href="eglCreateWindowSurface.xhtml" target="pagedisplay">eglCreateWindowSurface</a></li>
             </ul> <!-- End Level3 -->
         </li>
@@ -36,7 +39,9 @@
         <li>d
             <ul class="Level3">
                 <li><a href="eglDestroyContext.xhtml" target="pagedisplay">eglDestroyContext</a></li>
+                <li><a href="eglDestroyImage.xhtml" target="pagedisplay">eglDestroyImage</a></li>
                 <li><a href="eglDestroySurface.xhtml" target="pagedisplay">eglDestroySurface</a></li>
+                <li><a href="eglDestroySync.xhtml" target="pagedisplay">eglDestroySync</a></li>
             </ul> <!-- End Level3 -->
         </li>
         <a name="g"></a>
@@ -49,7 +54,9 @@
                 <li><a href="eglGetCurrentSurface.xhtml" target="pagedisplay">eglGetCurrentSurface</a></li>
                 <li><a href="eglGetDisplay.xhtml" target="pagedisplay">eglGetDisplay</a></li>
                 <li><a href="eglGetError.xhtml" target="pagedisplay">eglGetError</a></li>
+                <li><a href="eglGetPlatformDisplay.xhtml" target="pagedisplay">eglGetPlatformDisplay</a></li>
                 <li><a href="eglGetProcAddress.xhtml" target="pagedisplay">eglGetProcAddress</a></li>
+                <li><a href="eglGetSyncAttrib.xhtml" target="pagedisplay">eglGetSyncAttrib</a></li>
             </ul> <!-- End Level3 -->
         </li>
         <a name="i"></a>
@@ -101,6 +108,7 @@
                 <li><a href="eglWaitClient.xhtml" target="pagedisplay">eglWaitClient</a></li>
                 <li><a href="eglWaitGL.xhtml" target="pagedisplay">eglWaitGL</a></li>
                 <li><a href="eglWaitNative.xhtml" target="pagedisplay">eglWaitNative</a></li>
+                <li><a href="eglWaitSync.xhtml" target="pagedisplay">eglWaitSync</a></li>
             </ul> <!-- End Level3 -->
         </li>
         </ul> <!-- End Level2 -->

--- a/sdk/docs/man/html/indexflat.php
+++ b/sdk/docs/man/html/indexflat.php
@@ -46,6 +46,7 @@
                 <li><a href="eglCreatePbufferFromClientBuffer.xhtml" target="pagedisplay">eglCreatePbufferFromClientBuffer</a></li>
                 <li><a href="eglCreatePbufferSurface.xhtml" target="pagedisplay">eglCreatePbufferSurface</a></li>
                 <li><a href="eglCreatePixmapSurface.xhtml" target="pagedisplay">eglCreatePixmapSurface</a></li>
+                <li><a href="eglCreatePlatformWindowSurface.xhtml" target="pagedisplay">eglCreatePlatformWindowSurface</a></li>
                 <li><a href="eglCreateSync.xhtml" target="pagedisplay">eglCreateSync</a></li>
                 <li><a href="eglCreateWindowSurface.xhtml" target="pagedisplay">eglCreateWindowSurface</a></li>
             </ul> <!-- End Level3 -->

--- a/sdk/docs/man/html/indexflat.php
+++ b/sdk/docs/man/html/indexflat.php
@@ -39,11 +39,14 @@
         <li>c
             <ul class="Level3">
                 <li><a href="eglChooseConfig.xhtml" target="pagedisplay">eglChooseConfig</a></li>
+                <li><a href="eglClientWaitSync.xhtml" target="pagedisplay">eglClientWaitSync</a></li>
                 <li><a href="eglCopyBuffers.xhtml" target="pagedisplay">eglCopyBuffers</a></li>
                 <li><a href="eglCreateContext.xhtml" target="pagedisplay">eglCreateContext</a></li>
+                <li><a href="eglCreateImage.xhtml" target="pagedisplay">eglCreateImage</a></li>
                 <li><a href="eglCreatePbufferFromClientBuffer.xhtml" target="pagedisplay">eglCreatePbufferFromClientBuffer</a></li>
                 <li><a href="eglCreatePbufferSurface.xhtml" target="pagedisplay">eglCreatePbufferSurface</a></li>
                 <li><a href="eglCreatePixmapSurface.xhtml" target="pagedisplay">eglCreatePixmapSurface</a></li>
+                <li><a href="eglCreateSync.xhtml" target="pagedisplay">eglCreateSync</a></li>
                 <li><a href="eglCreateWindowSurface.xhtml" target="pagedisplay">eglCreateWindowSurface</a></li>
             </ul> <!-- End Level3 -->
         </li>
@@ -51,7 +54,9 @@
         <li>d
             <ul class="Level3">
                 <li><a href="eglDestroyContext.xhtml" target="pagedisplay">eglDestroyContext</a></li>
+                <li><a href="eglDestroyImage.xhtml" target="pagedisplay">eglDestroyImage</a></li>
                 <li><a href="eglDestroySurface.xhtml" target="pagedisplay">eglDestroySurface</a></li>
+                <li><a href="eglDestroySync.xhtml" target="pagedisplay">eglDestroySync</a></li>
             </ul> <!-- End Level3 -->
         </li>
         <a name="g"></a>
@@ -64,7 +69,9 @@
                 <li><a href="eglGetCurrentSurface.xhtml" target="pagedisplay">eglGetCurrentSurface</a></li>
                 <li><a href="eglGetDisplay.xhtml" target="pagedisplay">eglGetDisplay</a></li>
                 <li><a href="eglGetError.xhtml" target="pagedisplay">eglGetError</a></li>
+                <li><a href="eglGetPlatformDisplay.xhtml" target="pagedisplay">eglGetPlatformDisplay</a></li>
                 <li><a href="eglGetProcAddress.xhtml" target="pagedisplay">eglGetProcAddress</a></li>
+                <li><a href="eglGetSyncAttrib.xhtml" target="pagedisplay">eglGetSyncAttrib</a></li>
             </ul> <!-- End Level3 -->
         </li>
         <a name="i"></a>
@@ -116,6 +123,7 @@
                 <li><a href="eglWaitClient.xhtml" target="pagedisplay">eglWaitClient</a></li>
                 <li><a href="eglWaitGL.xhtml" target="pagedisplay">eglWaitGL</a></li>
                 <li><a href="eglWaitNative.xhtml" target="pagedisplay">eglWaitNative</a></li>
+                <li><a href="eglWaitSync.xhtml" target="pagedisplay">eglWaitSync</a></li>
             </ul> <!-- End Level3 -->
         </li>
         </ul> <!-- End Level2 -->

--- a/sdk/docs/man/html/indexflat.php
+++ b/sdk/docs/man/html/indexflat.php
@@ -46,6 +46,7 @@
                 <li><a href="eglCreatePbufferFromClientBuffer.xhtml" target="pagedisplay">eglCreatePbufferFromClientBuffer</a></li>
                 <li><a href="eglCreatePbufferSurface.xhtml" target="pagedisplay">eglCreatePbufferSurface</a></li>
                 <li><a href="eglCreatePixmapSurface.xhtml" target="pagedisplay">eglCreatePixmapSurface</a></li>
+                <li><a href="eglCreatePlatformPixmapSurface.xhtml" target="pagedisplay">eglCreatePlatformPixmapSurface</a></li>
                 <li><a href="eglCreatePlatformWindowSurface.xhtml" target="pagedisplay">eglCreatePlatformWindowSurface</a></li>
                 <li><a href="eglCreateSync.xhtml" target="pagedisplay">eglCreateSync</a></li>
                 <li><a href="eglCreateWindowSurface.xhtml" target="pagedisplay">eglCreateWindowSurface</a></li>

--- a/sdk/docs/man/reference.xml
+++ b/sdk/docs/man/reference.xml
@@ -138,13 +138,18 @@
     <xi:include href="eglBindAPI.xml"/>
     <xi:include href="eglBindTexImage.xml"/>
     <xi:include href="eglChooseConfig.xml"/>
+    <xi:include href="eglClientWaitSync.xml"/>
     <xi:include href="eglCopyBuffers.xml"/>
     <xi:include href="eglCreateContext.xml"/>
+    <xi:include href="eglCreateImage.xml"/>
     <xi:include href="eglCreatePbufferSurface.xml"/>
     <xi:include href="eglCreatePixmapSurface.xml"/>
+    <xi:include href="eglCreateSync.xml"/>
     <xi:include href="eglCreateWindowSurface.xml"/>
     <xi:include href="eglDestroyContext.xml"/>
+    <xi:include href="eglDestroyImage.xml"/>
     <xi:include href="eglDestroySurface.xml"/>
+    <xi:include href="eglDestroySync.xml"/>
     <xi:include href="eglGetConfigAttrib.xml"/>
     <xi:include href="eglGetConfigs.xml"/>
     <xi:include href="eglGetCurrentContext.xml"/>
@@ -152,7 +157,9 @@
     <xi:include href="eglGetCurrentSurface.xml"/>
     <xi:include href="eglGetDisplay.xml"/>
     <xi:include href="eglGetError.xml"/>
+    <xi:include href="eglGetPlatformDisplay.xml"/>
     <xi:include href="eglGetProcAddress.xml"/>
+    <xi:include href="eglGetSyncAttrib.xml"/>
     <xi:include href="eglInitialize.xml"/>
     <xi:include href="eglIntro.xml"/>
     <xi:include href="eglMakeCurrent.xml"/>
@@ -169,6 +176,7 @@
     <xi:include href="eglWaitClient.xml"/>
     <xi:include href="eglWaitGL.xml"/>
     <xi:include href="eglWaitNative.xml"/>
+    <xi:include href="eglWaitSync.xml"/>
   </chapter>
   <xi:include href="license-full.xml"/>
 </book>


### PR DESCRIPTION
This is based on the initial EGL 1.5 release of March 12, 2014. There
have been a couple of minor updates to the 1.5 Specification since then,
which will need to be reflected in these pages, but they should be
substantially complete.