### PR TITLE
man: fix eglGetProcAddress() function declaration

### DIFF
--- a/sdk/docs/man/docbook4/eglGetProcAddress.xml
+++ b/sdk/docs/man/docbook4/eglGetProcAddress.xml
@@ -23,7 +23,7 @@
         <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>void (* <function>eglGetProcAddress</function>)()</funcdef>
+                <funcdef>void * <function>eglGetProcAddress</function></funcdef>
                 <paramdef>char const * <parameter>procname</parameter></paramdef>
             </funcprototype>
         </funcsynopsis>

--- a/sdk/docs/man/eglGetProcAddress.xml
+++ b/sdk/docs/man/eglGetProcAddress.xml
@@ -20,7 +20,7 @@
         <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>void (* <function>eglGetProcAddress</function>)()</funcdef>
+                <funcdef>void * <function>eglGetProcAddress</function></funcdef>
                 <paramdef>char const * <parameter>procname</parameter></paramdef>
             </funcprototype>
         </funcsynopsis>

--- a/sdk/docs/man/html/eglGetProcAddress.xhtml
+++ b/sdk/docs/man/html/eglGetProcAddress.xhtml
@@ -22,7 +22,7 @@
           <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
             <tr>
               <td>
-                <code class="funcdef">void (* <strong class="fsfunc">eglGetProcAddress</strong>)()(</code>
+                <code class="funcdef">void * <strong class="fsfunc">eglGetProcAddress</strong>(</code>
               </td>
               <td>char const * <var class="pdparam">procname</var><code>)</code>;</td>
             </tr>

--- a/sdk/docs/man/xhtml/eglGetProcAddress.html
+++ b/sdk/docs/man/xhtml/eglGetProcAddress.html
@@ -233,7 +233,7 @@
           <table xmlns="" border="0" summary="Function synopsis" cellspacing="0" cellpadding="0">
             <tr valign="bottom">
               <td>
-                <code xmlns="http://www.w3.org/1999/xhtml" class="funcdef">void (* <strong class="fsfunc">eglGetProcAddress</strong>)()(</code>
+                <code xmlns="http://www.w3.org/1999/xhtml" class="funcdef">void * <strong class="fsfunc">eglGetProcAddress</strong>(</code>
                 <td>char const *  <var xmlns="http://www.w3.org/1999/xhtml" class="pdparam">procname</var><code>)</code></td>
               </td>
             </tr>


### PR DESCRIPTION
Rendered, it looked like this:

    void (* eglGetProcAddress)()(char const * procname);

That declaration was invalid, but my closest interpretation would've been that `eglGetProcAddress` was a pointer to a function that returns a function that takes a procname and doesn't return anything. Not really accurate.

This changes it to look like this instead:.

    void * eglGetProcAddress(char const * procname);

A function that takes a procname and returns a `void*` (to be cast into the actual function).