### PR TITLE
Add passthrough version of Display P3 colorspace

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: e87f2f2fd2 $ on $Git commit date: 2018-09-30 21:02:01 -0700 $
+** Khronos $Git commit SHA1: 726475c203 $ on $Git commit date: 2018-10-03 23:51:49 -0700 $
 */
 
 #include <EGL/eglplatform.h>
 
-/* Generated on date 20180930 */
+/* Generated on date 20181204 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: e87f2f2fd2 $ on $Git commit date: 2018-09-30 21:02:01 -0700 $
+** Khronos $Git commit SHA1: 726475c203 $ on $Git commit date: 2018-10-03 23:51:49 -0700 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20180930
+#define EGL_EGLEXT_VERSION 20181204
 
 /* Generated C header for:
  * API: egl
@@ -716,6 +716,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint a
 #define EGL_EXT_gl_colorspace_display_p3_linear 1
 #define EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT 0x3362
 #endif /* EGL_EXT_gl_colorspace_display_p3_linear */
+
+#ifndef EGL_EXT_gl_colorspace_display_p3_passthrough
+#define EGL_EXT_gl_colorspace_display_p3_passthrough 1
+#define EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT 0x3490
+#endif /* EGL_EXT_gl_colorspace_display_p3_passthrough */
 
 #ifndef EGL_EXT_gl_colorspace_scrgb
 #define EGL_EXT_gl_colorspace_scrgb 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -893,6 +893,10 @@
     <enums namespace="EGL" start="0x3480" end="0x348F" vendor="ANGLE" comment="Reserved for Courtney Goeltzenleuchter - ANGLE (gitlab EGL bug 7)">
             <unused start="0x3480" end="0x348F"/>
     </enums>
+    <enums namespace="EGL" start="0x3490" end="0x349F" vendor="EXT" comment="Reserved for Courtney Goeltzenleuchter - Android (gitlab EGL bug 69)">
+        <enum value="0x3490" name="EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT"/>
+            <unused start="0x3491" end="0x349F"/>
+    </enums>
 
 <!-- Please remember that new enumerant allocations must be obtained by
      request to the Khronos API registrar (see comments at the top of this
@@ -903,8 +907,8 @@
 
 <!-- Reservable for future use. To generate a new range, allocate multiples
      of 16 starting at the lowest available point in this block. -->
-    <enums namespace="EGL" start="0x3490" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
-            <unused start="0x3490" end="0x3FFF"/>
+    <enums namespace="EGL" start="0x34A0" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
+            <unused start="0x34A0" end="0x3FFF"/>
     </enums>
 
     <enums namespace="EGL" start="0x8F70" end="0x8F7F" vendor="HI" comment="For Mark Callow, Khronos bug 4055. Shared with GL.">
@@ -2249,6 +2253,11 @@
         <extension name="EGL_EXT_gl_colorspace_display_p3" supported="egl">
             <require>
                 <enum name="EGL_GL_COLORSPACE_DISPLAY_P3_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_display_p3_passthrough" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_image_dma_buf_import" supported="egl">

--- a/extensions/EXT/EGL_EXT_gl_colorspace_display_p3_passthrough.txt
+++ b/extensions/EXT/EGL_EXT_gl_colorspace_display_p3_passthrough.txt
@@ -1,0 +1,139 @@
+Name
+
+    EXT_gl_colorspace_display_p3_passthrough
+
+Name Strings
+
+    EGL_EXT_gl_colorspace_display_p3_passthrough
+
+Contributors
+
+    Chris Forbes
+    Courtney Goeltzenleuchter
+
+Contact
+
+    Courtney Goeltzenleuchter (courtneygo 'at' google.com)
+
+IP Status
+
+    No known IP claims.
+
+Status
+
+    Draft
+
+Version
+
+     Version 1 - Dec 4, 2018
+
+Number
+
+    EGL Extension #130
+
+Extension Type
+
+    EGL display extension
+
+Dependencies
+
+    This extension is written against the wording of the EGL 1.5
+    specification (August 27, 2014).
+
+    This extension requires EGL_KHR_gl_colorspace.
+
+Overview
+
+    Applications that want to use the Display-P3 color space (DCI-P3 primaries
+    with sRGB-like transfer function) can use this extension to
+    communicate to the platform that framebuffer contents represent colors in
+    the non-linear Display-P3 color space.
+    The application is responsible for producing appropriate framebuffer
+    contents. An application would want to use this extension rather than
+    EGL_EXT_gl_colorspace_display_p3 if they apply the sRGB transfer function
+    themselves and do not need the HW to do it.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    Accepted as attribute values for EGL_GL_COLORSPACE by
+    eglCreateWindowSurface, eglCreatePbufferSurface and eglCreatePixmapSurface:
+
+    [[ If EGL_EXT_gl_colorspace_display_p3_linear is supported ]]
+
+        EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT         0x3490
+
+Modifications to the EGL 1.5 Specification
+
+    Insert below text in the 3rd paragraph on page 33 in 3.5.1 "Creating On-
+    Screen Rendering Surfaces, before "The default value of EGL_GL_COLORSPACE
+    is EGL_GL_COLORSPACE_LINEAR.":
+
+    [[ If EGL_EXT_gl_colorspace_display_p3_passthrough is supported ]]
+
+    If its value is EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT, then a
+    non-linear, sRGB encoded Display-P3 color space is assumed, with a
+    corresponding GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING value of GL_LINEAR.
+    The application is responsible for applying the appropriate transfer
+    function when writing and reading pixels.
+
+    Insert below text after the 4th paragraph on the same page:
+
+    Note that the EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT attribute
+    indicates that a colorspace of Display P3 will be communicated to the
+    Window system. While EGL itself is color space agnostic, the surface
+    will eventually be presented to a display device with specific color
+    reproduction characteristics. If any color space transformations are
+    necessary before an image can be displayed, the color space of the
+    presented image must be known to the window system.
+
+Errors
+
+    Modify below error in the "Errors" section on page 34:
+
+    "If config does not support the OpenVG colorspace or alpha format at-
+    tributes specified in attrib list (as defined for eglCreatePlatformWindow-
+    Surface), an EGL_BAD_MATCH error is generated."
+
+    To include OpenGL colorspace as well:
+
+    "If config does not support the OpenGL colorspace, the OpenVG colorspace or
+    alpha format attributes specified in attrib list (as defined for eglCreate-
+    PlatformWindowSurface), an EGL_BAD_MATCH error is generated."
+
+Issues
+
+    1. When creating an EGL surface, what happens when the specified colorspace
+       is not compatible with or supported by the EGLConfig?
+
+       RESOLVED: There is currently no way to query the compatibility of a
+       EGLConfig and colorspace pair. So the only option is to define an error
+       case similar to that of OpenVG colorspace, i.e. if config does not
+       support the colorspace specified in attrib list (as defined for egl-
+       CreateWindowSurface, eglCreatePbufferSurface and eglCreatePixmapSurface),
+       an EGL_BAD_MATCH error is generated.
+
+   2. Why the new enum instead of DISPLAY_P3_EXT + EXT_srgb_write_control?
+
+      RESOLVED:
+      We want to rely on "surface state" rather than a "context state", e.g.
+      EXT_srgb_write_control is global where we only want behavior to apply to
+      specific surface.
+
+   3. Should sRGB framebuffer support affect the pixel path?
+
+      RESOLVED:  No.
+
+      sRGB rendering is defined by GL/GLES. Specifically, glReadPixels and
+      other pixel paths operations are not affected by sRGB rendering. But
+      glBlitFramebuffer is. Though, of course, if this extension were to
+      apply it would be a no-op.
+
+Revision History
+
+    Version 1, 2018/12/04
+      - Internal revisions
+

--- a/index.php
+++ b/index.php
@@ -325,6 +325,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=129> <a href="extensions/EXT/EGL_EXT_client_sync.txt">EGL_EXT_client_sync</a>
 </li>
+<li value=130> <a href="extensions/EXT/EGL_EXT_gl_colorspace_display_p3_passthrough.txt">EGL_EXT_gl_colorspace_display_p3_passthrough</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -669,4 +669,9 @@ extension EGL_EXT_client_sync {
     flags       public
     filename    extensions/EXT/EGL_EXT_client_sync.txt
 }
-# Next free extension number: 130
+extension EGL_EXT_gl_colorspace_display_p3_passthrough {
+    number      130
+    flags       public
+    filename    extensions/EXT/EGL_EXT_gl_colorspace_display_p3_passthrough.txt
+}
+# Next free extension number: 131


### PR DESCRIPTION
Discovered that there was no way for an application to specify
they want to use the non-linear Display P3 colorspace but do not
want the HW to apply the transfer function, instead the application
is responsible for applying the transfer function.

Bug #69