### PR TITLE
Alternate fix for #67 - use the correct prototype as defined in the spec

### DIFF
--- a/sdk/docs/man/eglGetProcAddress.xml
+++ b/sdk/docs/man/eglGetProcAddress.xml
@@ -20,8 +20,8 @@
         <title>C Specification</title>
         <funcsynopsis>
             <funcprototype>
-                <funcdef>void (* <function>eglGetProcAddress</function>)()</funcdef>
-                <paramdef>char const * <parameter>procname</parameter></paramdef>
+                <funcdef>void (* <function>eglGetProcAddress</function></funcdef>
+                <paramdef>char const * <parameter>procname</parameter>))(void</paramdef>
             </funcprototype>
         </funcsynopsis>
     </refsynopsisdiv>

--- a/sdk/docs/man/html/eglGetProcAddress.xhtml
+++ b/sdk/docs/man/html/eglGetProcAddress.xhtml
@@ -22,9 +22,9 @@
           <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
             <tr>
               <td>
-                <code class="funcdef">void (* <strong class="fsfunc">eglGetProcAddress</strong>)()(</code>
+                <code class="funcdef">void (* <strong class="fsfunc">eglGetProcAddress</strong>(</code>
               </td>
-              <td>char const * <var class="pdparam">procname</var><code>)</code>;</td>
+              <td>char const * <var class="pdparam">procname</var>))(void<code>)</code>;</td>
             </tr>
           </table>
           <div class="funcprototype-spacer"> </div>


### PR DESCRIPTION
The Docbook XML syntax I came up with for this function pointer declaration is wonky, but the rendered result comes out correctly.