### PR TITLE
Add KHRONOS_STATIC to allow static linking on Windows.

### DIFF
--- a/api/KHR/khrplatform.h
+++ b/api/KHR/khrplatform.h
@@ -90,12 +90,20 @@
  *                                  int arg2) KHRONOS_APIATTRIBUTES;
  */
 
+#if defined(__SCITECH_SNAP__) && !defined(KHRONOS_STATIC)
+#   define KHRONOS_STATIC 1
+#endif
+
 /*-------------------------------------------------------------------------
  * Definition of KHRONOS_APICALL
  *-------------------------------------------------------------------------
  * This precedes the return type of the function in the function prototype.
  */
-#if defined(_WIN32) && !defined(__SCITECH_SNAP__)
+#if defined(KHRONOS_STATIC)
+    /* If the preprocessor constant KHRONOS_STATIC is defined, make the
+     * header compatible with static linking. */
+#   define KHRONOS_APICALL
+#elif defined(_WIN32)
 #   define KHRONOS_APICALL __declspec(dllimport)
 #elif defined (__SYMBIAN32__)
 #   define KHRONOS_APICALL IMPORT_C
@@ -111,7 +119,7 @@
  * This follows the return type of the function  and precedes the function
  * name in the function prototype.
  */
-#if defined(_WIN32) && !defined(_WIN32_WCE) && !defined(__SCITECH_SNAP__)
+#if defined(_WIN32) && !defined(_WIN32_WCE) && !defined(KHRONOS_STATIC)
     /* Win32 but not WinCE */
 #   define KHRONOS_APIENTRY __stdcall
 #else


### PR DESCRIPTION
I have encountered multiple situations where it is desirable to statically link against a software implementation of EGL on Windows. Add the preprocessor constant KHRONOS_STATIC that disables the annotation of EGL entry points as DLL-imported.