### PR TITLE
Add support for Emscripten in EGL/eglplatform.h.

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -77,6 +77,12 @@ typedef HDC     EGLNativeDisplayType;
 typedef HBITMAP EGLNativePixmapType;
 typedef HWND    EGLNativeWindowType;
 
+#elif defined(__EMSCRIPTEN__)
+
+typedef int EGLNativeDisplayType;
+typedef int EGLNativePixmapType;
+typedef int EGLNativeWindowType;
+
 #elif defined(__WINSCW__) || defined(__SYMBIAN32__)  /* Symbian */
 
 typedef int   EGLNativeDisplayType;


### PR DESCRIPTION
The Emscripten toolchain for WebAssembly defines the native EGL handle
types as integers in its custom eglplatform.h header. Make the Khronos
version compatible with it.