### PR TITLE
Add EGL_NO_X11 define for unix platforms that don't want to use X11

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -116,6 +116,12 @@ typedef intptr_t EGLNativeDisplayType;
 typedef intptr_t EGLNativePixmapType;
 typedef intptr_t EGLNativeWindowType;
 
+#elif defined(__unix__) && defined(EGL_NO_X11)
+
+typedef void             *EGLNativeDisplayType;
+typedef khronos_uintptr_t EGLNativePixmapType;
+typedef khronos_uintptr_t EGLNativeWindowType;
+
 #elif defined(__unix__) || defined(USE_X11)
 
 /* X11 (tentative)  */


### PR DESCRIPTION
This is equivalent to the already existing USE_OZONE define, used in the Chromium project. The purpose of this define is to be more explicit about it's meaning, making it easier to understand from the client code's perspective.