### PR TITLE
Add EGL_WL_bind_wayland_display and EGL_WL_create_wayland_buffer_from_image

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -33,7 +33,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: cb927ca98d $ on $Git commit date: 2019-08-08 01:05:38 -0700 $
+** Khronos $Git commit SHA1: 0f3a3945bf $ on $Git commit date: 2019-11-13 13:25:18 +0000 $
 */
 
 #include <EGL/eglplatform.h>
@@ -42,7 +42,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20190808 */
+/* Generated on date 20191212 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: cb927ca98d $ on $Git commit date: 2019-08-08 01:05:38 -0700 $
+** Khronos $Git commit SHA1: 0f3a3945bf $ on $Git commit date: 2019-11-13 13:25:18 +0000 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20190808
+#define EGL_EGLEXT_VERSION 20191212
 
 /* Generated C header for:
  * API: egl
@@ -1361,6 +1361,40 @@ EGLAPI EGLuint64NV EGLAPIENTRY eglGetSystemTimeNV (void);
 #define EGL_TIZEN_image_native_surface 1
 #define EGL_NATIVE_SURFACE_TIZEN          0x32A1
 #endif /* EGL_TIZEN_image_native_surface */
+
+#ifndef EGL_WL_bind_wayland_display
+#define EGL_WL_bind_wayland_display 1
+#define PFNEGLBINDWAYLANDDISPLAYWL PFNEGLBINDWAYLANDDISPLAYWLPROC
+#define PFNEGLUNBINDWAYLANDDISPLAYWL PFNEGLUNBINDWAYLANDDISPLAYWLPROC
+#define PFNEGLQUERYWAYLANDBUFFERWL PFNEGLQUERYWAYLANDBUFFERWLPROC
+struct wl_display;
+struct wl_resource;
+#define EGL_WAYLAND_BUFFER_WL             0x31D5
+#define EGL_WAYLAND_PLANE_WL              0x31D6
+#define EGL_TEXTURE_Y_U_V_WL              0x31D7
+#define EGL_TEXTURE_Y_UV_WL               0x31D8
+#define EGL_TEXTURE_Y_XUXV_WL             0x31D9
+#define EGL_TEXTURE_EXTERNAL_WL           0x31DA
+#define EGL_WAYLAND_Y_INVERTED_WL         0x31DB
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLBINDWAYLANDDISPLAYWLPROC) (EGLDisplay dpy, struct wl_display *display);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLUNBINDWAYLANDDISPLAYWLPROC) (EGLDisplay dpy, struct wl_display *display);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYWAYLANDBUFFERWLPROC) (EGLDisplay dpy, struct wl_resource *buffer, EGLint attribute, EGLint *value);
+#ifdef EGL_EGLEXT_PROTOTYPES
+EGLAPI EGLBoolean EGLAPIENTRY eglBindWaylandDisplayWL (EGLDisplay dpy, struct wl_display *display);
+EGLAPI EGLBoolean EGLAPIENTRY eglUnbindWaylandDisplayWL (EGLDisplay dpy, struct wl_display *display);
+EGLAPI EGLBoolean EGLAPIENTRY eglQueryWaylandBufferWL (EGLDisplay dpy, struct wl_resource *buffer, EGLint attribute, EGLint *value);
+#endif
+#endif /* EGL_WL_bind_wayland_display */
+
+#ifndef EGL_WL_create_wayland_buffer_from_image
+#define EGL_WL_create_wayland_buffer_from_image 1
+#define PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWLPROC
+struct wl_buffer;
+typedef struct wl_buffer *(EGLAPIENTRYP PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWLPROC) (EGLDisplay dpy, EGLImageKHR image);
+#ifdef EGL_EGLEXT_PROTOTYPES
+EGLAPI struct wl_buffer *EGLAPIENTRY eglCreateWaylandBufferFromImageWL (EGLDisplay dpy, EGLImageKHR image);
+#endif
+#endif /* EGL_WL_create_wayland_buffer_from_image */
 
 #ifdef __cplusplus
 }

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -49,6 +49,9 @@
         <type name="NativePixmapType" requires="eglplatform"/>
         <type name="NativeWindowType" requires="eglplatform"/>
         <type>struct <name>AHardwareBuffer</name>;</type>
+        <type>struct <name>wl_buffer</name>;</type>
+        <type>struct <name>wl_display</name>;</type>
+        <type>struct <name>wl_resource</name>;</type>
         <!-- Dummy placeholders for non-EGL types -->
         <type name="Bool"/>
             <!-- These are actual EGL types.  -->
@@ -89,7 +92,13 @@
     EGLint iHeight;
     EGLint iStride;
 };</type>
+        <!-- Backwards-compatibility hack: Downstream implementations shipped
+             incorrect function pointer names for some years. -->
         <type>typedef void (<apientry/> *<name>EGLDEBUGPROCKHR</name>)(EGLenum error,const char *command,EGLint messageType,EGLLabelKHR threadLabel,EGLLabelKHR objectLabel,const char* message);</type>
+	<type>#define <name>PFNEGLBINDWAYLANDDISPLAYWL</name> PFNEGLBINDWAYLANDDISPLAYWLPROC</type>
+	<type>#define <name>PFNEGLUNBINDWAYLANDDISPLAYWL</name> PFNEGLUNBINDWAYLANDDISPLAYWLPROC</type>
+	<type>#define <name>PFNEGLQUERYWAYLANDBUFFERWL</name> PFNEGLQUERYWAYLANDBUFFERWLPROC</type>
+	<type>#define <name>PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL</name> PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWLPROC</type>
     </types>
 
     <!-- SECTION: EGL enumerant (token) definitions. -->
@@ -581,9 +590,25 @@
         <enum value="0x31D7" name="EGL_PLATFORM_GBM_MESA" alias="EGL_PLATFORM_GBM_KHR"/>
         <enum value="0x31D8" name="EGL_PLATFORM_WAYLAND_KHR"/>
         <enum value="0x31D8" name="EGL_PLATFORM_WAYLAND_EXT" alias="EGL_PLATFORM_WAYLAND_KHR"/>
-            <unused start="0x31D9" end="0x31DC"/>
+            <unused start="0x31DC" end="0x31DC"/>
         <enum value="0x31DD" name="EGL_PLATFORM_SURFACELESS_MESA"/>
             <unused start="0x31DE" end="0x31DF"/>
+    </enums>
+
+    <!-- Due to an oversight in development, these enums alias the above MESA
+         vendor range for EGL the X11/GBM/Wayland/surfaceless platforms.
+         They are both currently in wide use and cannot be changed, however
+         the tokens cannot be used in the same contexts and the aliasing is
+         therefore harmless. Future Wayland tokens should not create further
+         aliasing in this range.-->
+    <enums namespace="EGL" start="0x31D5" end="0x31DB" vendor="WL" comment="EGL_WL_bind_wayland_display">
+        <enum value="0x31D5" name="EGL_WAYLAND_BUFFER_WL"/>
+        <enum value="0x31D6" name="EGL_WAYLAND_PLANE_WL"/>
+        <enum value="0x31D7" name="EGL_TEXTURE_Y_U_V_WL"/>
+        <enum value="0x31D8" name="EGL_TEXTURE_Y_UV_WL"/>
+        <enum value="0x31D9" name="EGL_TEXTURE_Y_XUXV_WL"/>
+        <enum value="0x31DA" name="EGL_TEXTURE_EXTERNAL_WL"/>
+        <enum value="0x31DB" name="EGL_WAYLAND_Y_INVERTED_WL"/>
     </enums>
 
     <enums namespace="EGL" start="0x31E0" end="0x31EF" vendor="HI" comment="Reserved for Mark Callow (Khronos bug 6799)">
@@ -1902,6 +1927,28 @@
             <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSwapPolicyEXT</name></proto>
             <param><ptype>EGLint</ptype> <name>external_win_id</name></param>
             <param><ptype>EGLint</ptype> <name>policy</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglBindWaylandDisplayWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param>struct <ptype>wl_display</ptype> *<name>display</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglUnbindWaylandDisplayWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param>struct <ptype>wl_display</ptype> *<name>display</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglQueryWaylandBufferWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param>struct <ptype>wl_resource</ptype> *<name>buffer</name></param>
+            <param><ptype>EGLint</ptype> <name>attribute</name></param>
+            <param><ptype>EGLint</ptype> *<name>value</name></param>
+        </command>
+        <command>
+            <proto>struct <ptype>wl_buffer</ptype> *<name>eglCreateWaylandBufferFromImageWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLImageKHR</ptype> <name>image</name></param>
         </command>
     </commands>
 
@@ -3279,6 +3326,30 @@
                 <enum name="EGL_BOTTOM_NV"/>
                 <enum name="EGL_X_AXIS_NV"/>
                 <enum name="EGL_Y_AXIS_NV"/>
+            </require>
+        </extension>
+        <extension name="EGL_WL_bind_wayland_display" supported="egl">
+            <require>
+                <enum name="EGL_WAYLAND_BUFFER_WL"/>
+                <enum name="EGL_WAYLAND_PLANE_WL"/>
+                <enum name="EGL_TEXTURE_Y_U_V_WL"/>
+                <enum name="EGL_TEXTURE_Y_UV_WL"/>
+                <enum name="EGL_TEXTURE_Y_XUXV_WL"/>
+                <enum name="EGL_TEXTURE_EXTERNAL_WL"/>
+                <enum name="EGL_WAYLAND_Y_INVERTED_WL"/>
+
+                <command name="eglBindWaylandDisplayWL"/>
+                <command name="eglUnbindWaylandDisplayWL"/>
+                <command name="eglQueryWaylandBufferWL"/>
+                <type name="PFNEGLBINDWAYLANDDISPLAYWL"/>
+                <type name="PFNEGLUNBINDWAYLANDDISPLAYWL"/>
+                <type name="PFNEGLQUERYWAYLANDBUFFERWL"/>
+            </require>
+        </extension>
+        <extension name="EGL_WL_create_wayland_buffer_from_image" supported="egl">
+            <require>
+                <command name="eglCreateWaylandBufferFromImageWL"/>
+                <type name="PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL"/>
             </require>
         </extension>
     </extensions>

--- a/extensions/WL/EGL_WL_bind_wayland_display.txt
+++ b/extensions/WL/EGL_WL_bind_wayland_display.txt
@@ -1,0 +1,217 @@
+Name
+
+    WL_bind_wayland_display
+
+Name Strings
+
+    EGL_WL_bind_wayland_display
+
+Contact
+
+    Kristian Høgsberg <krh@bitplanet.net>
+    Benjamin Franzke <benjaminfranzke@googlemail.com>
+
+Status
+
+    Complete
+
+Version
+
+    Version 6, July 14, 2017
+
+Number
+
+    EGL Extension #136
+
+Dependencies
+
+    Requires EGL 1.4 or later.  This extension is written against the
+    wording of the EGL 1.4 specification.
+
+    EGL_KHR_image_base is required.
+
+Overview
+
+    This extension provides entry points for binding and unbinding the
+    wl_display of a Wayland compositor to an EGLDisplay.  Binding a
+    wl_display means that the EGL implementation should provide one or
+    more interfaces in the Wayland protocol to allow clients to create
+    wl_buffer objects.  On the server side, this extension also
+    provides a new target for eglCreateImageKHR, to create an EGLImage
+    from a wl_buffer.
+
+    Adding an implementation-specific Wayland interface, allows the
+    EGL implementation to define specific wayland requests and events,
+    needed for buffer sharing in an EGL Wayland platform.
+
+IP Status
+
+    Open-source; freely implementable.
+
+New Procedures and Functions
+
+    EGLBoolean eglBindWaylandDisplayWL(EGLDisplay dpy,
+                                       struct wl_display *display);
+
+    EGLBoolean eglUnbindWaylandDisplayWL(EGLDisplay dpy,
+                                         struct wl_display *display);
+
+    EGLBoolean eglQueryWaylandBufferWL(EGLDisplay dpy,
+                                       struct wl_resource *buffer,
+                                       EGLint attribute, EGLint *value);
+
+New Tokens
+
+    Accepted as <target> in eglCreateImageKHR
+
+        EGL_WAYLAND_BUFFER_WL                   0x31D5
+
+    Accepted in the <attrib_list> parameter of eglCreateImageKHR:
+
+        EGL_WAYLAND_PLANE_WL                    0x31D6
+
+    Possible values for EGL_TEXTURE_FORMAT:
+
+        EGL_TEXTURE_Y_U_V_WL                    0x31D7
+        EGL_TEXTURE_Y_UV_WL                     0x31D8
+        EGL_TEXTURE_Y_XUXV_WL                   0x31D9
+        EGL_TEXTURE_EXTERNAL_WL                 0x31DA
+
+    Accepted in the <attribute> parameter of eglQueryWaylandBufferWL:
+
+        EGL_TEXTURE_FORMAT                      0x3080
+        EGL_WAYLAND_Y_INVERTED_WL               0x31DB
+
+
+Additions to the EGL 1.4 Specification:
+
+    To bind a server-side wl_display to an EGLDisplay, call
+
+        EGLBoolean eglBindWaylandDisplayWL(EGLDisplay dpy,
+                                           struct wl_display *display);
+
+    To unbind a server-side wl_display from an EGLDisplay, call
+    
+        EGLBoolean eglUnbindWaylandDisplayWL(EGLDisplay dpy,
+                                             struct wl_display *display);
+
+    eglBindWaylandDisplayWL returns EGL_FALSE when there is already a
+    wl_display bound to EGLDisplay otherwise EGL_TRUE.
+
+    eglUnbindWaylandDisplayWL returns EGL_FALSE when there is no
+    wl_display bound to the EGLDisplay currently otherwise EGL_TRUE.
+
+    XXXXXXXX 
+    EGL_WAYLAND_BUFFER_WL
+
+
+    To query attributes of a wl_buffer created by the EGL
+    implementation installed by eglBindWaylandDisplayWL, call:
+
+        EGLBoolean eglQueryWaylandBufferWL(EGLDisplay dpy,
+                                           struct wl_resource *buffer,
+                                           EGLint attribute,
+					   EGLint *value);
+
+    A wl_buffer can have several planes, typically in case of planar
+    YUV formats.  Depending on the exact YUV format in use, the
+    compositor will have to create one or more EGLImages for the
+    various planes.  The eglQueryWaylandBufferWL function should be
+    used to first query the wl_buffer texture format using
+    EGL_TEXTURE_FORMAT as the attribute.  If the wl_buffer object is
+    not an EGL wl_buffer (wl_shm and other wayland extensions can
+    create wl_buffer objects of different types), this query will
+    return EGL_FALSE.  In that case the wl_buffer can not be used with
+    EGL and the compositor should have another way to get the buffer
+    contents.
+
+    If eglQueryWaylandBufferWL succeeds, the returned value will be
+    one of EGL_TEXTURE_RGB, EGL_TEXTURE_RGBA, EGL_TEXTURE_Y_U_V_WL,
+    EGL_TEXTURE_Y_UV_WL, EGL_TEXTURE_Y_XUXV_WL.  The value returned
+    describes how many EGLImages must be used, which components will
+    be sampled from each EGLImage and how they map to rgba components
+    in the shader.  The naming conventions separates planes by _ and
+    within each plane, the order or R, G, B, A, Y, U, and V indicates
+    how those components map to the rgba value returned by the
+    sampler.  X indicates that the corresponding component in the rgba
+    value isn't used.
+
+    RGB and RGBA buffer types:
+
+        EGL_TEXTURE_RGB
+                One plane, samples RGB from the texture to rgb in the
+                shader.  Alpha channel is not valid.
+
+        EGL_TEXTURE_RGBA
+                One plane, samples RGBA from the texture to rgba in the
+                shader.
+
+    YUV buffer types:
+
+        EGL_TEXTURE_Y_U_V_WL
+                Three planes, samples Y from the first plane to r in
+                the shader, U from the second plane to r, and V from
+                the third plane to r.
+
+        EGL_TEXTURE_Y_UV_WL
+                Two planes, samples Y from the first plane to r in
+                the shader, U and V from the second plane to rg.
+
+        EGL_TEXTURE_Y_XUXV_WL
+                Two planes, samples Y from the first plane to r in
+                the shader, U and V from the second plane to g and a.
+
+        EGL_TEXTURE_EXTERNAL_WL
+                Treated as a single plane texture, but sampled with
+                samplerExternalOES according to OES_EGL_image_external
+
+    After querying the wl_buffer layout, create EGLImages for the
+    planes by calling eglCreateImageKHR with wl_buffer as
+    EGLClientBuffer, EGL_WAYLAND_BUFFER_WL as the target, NULL
+    context.  If no attributes are given, an EGLImage will be created
+    for the first plane.  For multi-planar buffers, specify the plane
+    to create the EGLImage for by using the EGL_WAYLAND_PLANE_WL
+    attribute.  The value of the attribute is the index of the plane,
+    as defined by the buffer format.  Writing to an EGLImage created
+    from a wl_buffer in any way (such as glTexImage2D, binding the
+    EGLImage as a renderbuffer etc) will result in undefined behavior.
+
+    Further, eglQueryWaylandBufferWL accepts attributes EGL_WIDTH and
+    EGL_HEIGHT to query the width and height of the wl_buffer.
+
+    Also, eglQueryWaylandBufferWL may accept
+    EGL_WAYLAND_Y_INVERTED_WL attribute to query orientation of
+    wl_buffer. If EGL_WAYLAND_Y_INVERTED_WL is supported
+    eglQueryWaylandBufferWL returns EGL_TRUE and value is a boolean
+    that tells if wl_buffer is y-inverted or not. If
+    EGL_WAYLAND_Y_INVERTED_WL is not supported
+    eglQueryWaylandBufferWL returns EGL_FALSE, in that case
+    wl_buffer should be treated as if value of
+    EGL_WAYLAND_Y_INVERTED_WL was EGL_TRUE.
+
+Issues
+
+Revision History
+
+    Version 1, March 1, 2011
+        Initial draft (Benjamin Franzke)
+    Version 2, July 5, 2012
+        Add EGL_WAYLAND_PLANE_WL attribute to allow creating an EGLImage
+        for different planes of planar buffer. (Kristian Høgsberg)
+    Version 3, July 10, 2012
+        Add eglQueryWaylandBufferWL and the various buffer
+        formats. (Kristian Høgsberg)
+    Version 4, July 19, 2012
+        Use EGL_TEXTURE_FORMAT, EGL_TEXTURE_RGB, and EGL_TEXTURE_RGBA,
+        and just define the new YUV texture formats.  Add support for
+        EGL_WIDTH and EGL_HEIGHT in the query attributes (Kristian Høgsberg)
+    Version 5, July 16, 2013
+        Change eglQueryWaylandBufferWL to take a resource pointer to the
+        buffer instead of a pointer to a struct wl_buffer, as the latter has
+        been deprecated. (Ander Conselvan de Oliveira)
+    Version 6, September 16, 2013
+        Add EGL_WAYLAND_Y_INVERTED_WL attribute to allow specifying
+        wl_buffer's orientation.
+    Version 7, July 14, 2017
+        Add EGL_WAYLAND_BUFFER_WL EGLImage target. Reword for inclusion in
+	Khronos registry.

--- a/extensions/WL/EGL_WL_create_wayland_buffer_from_image.txt
+++ b/extensions/WL/EGL_WL_create_wayland_buffer_from_image.txt
@@ -1,0 +1,101 @@
+Name
+
+    WL_create_wayland_buffer_from_image
+
+Name Strings
+
+    EGL_WL_create_wayland_buffer_from_image
+
+Contributors
+
+    Neil Roberts
+    Axel Davy
+    Daniel Stone
+
+Contact
+
+    Neil Roberts <neil.s.roberts@intel.com>
+
+Status
+
+    Complete
+
+Version
+
+    Version 2, October 25, 2013
+
+Number
+
+    EGL Extension #137
+
+Dependencies
+
+    Requires EGL 1.4 or later.  This extension is written against the
+    wording of the EGL 1.4 specification.
+
+    EGL_KHR_base_image is required.
+
+Overview
+
+    This extension provides an entry point to create a wl_buffer which shares
+    its contents with a given EGLImage. The expected use case for this is in a
+    nested Wayland compositor which is using subsurfaces to present buffers
+    from its clients. Using this extension it can attach the client buffers
+    directly to the subsurface without having to blit the contents into an
+    intermediate buffer. The compositing can then be done in the parent
+    compositor.
+
+    The nested compositor can create an EGLImage from a client buffer resource
+    using the existing WL_bind_wayland_display extension. It should also be
+    possible to create buffers using other types of images although there is
+    no expected use case for that.
+
+IP Status
+
+    Open-source; freely implementable.
+
+New Procedures and Functions
+
+    struct wl_buffer *eglCreateWaylandBufferFromImageWL(EGLDisplay dpy,
+                                                        EGLImageKHR image);
+
+New Tokens
+
+    None.
+
+Additions to the EGL 1.4 Specification:
+
+    To create a client-side wl_buffer from an EGLImage call
+
+      struct wl_buffer *eglCreateWaylandBufferFromImageWL(EGLDisplay dpy,
+                                                          EGLImageKHR image);
+
+    The returned buffer will share the contents with the given EGLImage. Any
+    updates to the image will also be updated in the wl_buffer. Typically the
+    EGLImage will be generated in a nested Wayland compositor using a buffer
+    resource from a client via the EGL_WL_bind_wayland_display extension.
+
+    If there was an error then the function will return NULL. In particular it
+    will generate EGL_BAD_MATCH if the implementation is not able to represent
+    the image as a wl_buffer. The possible reasons for this error are
+    implementation-dependant but may include problems such as an unsupported
+    format or tiling mode or that the buffer is in memory that is inaccessible
+    to the GPU that the given EGLDisplay is using.
+
+Issues
+
+    1) Under what circumstances can the EGL_BAD_MATCH error be generated? Does
+       this include for example unsupported tiling modes?
+
+       RESOLVED: Yes, the EGL_BAD_MATCH error can be generated for any reason
+       which prevents the implementation from representing the image as a
+       wl_buffer. For example, these problems can be but are not limited to
+       unsupported tiling modes, inaccessible memory or an unsupported pixel
+       format.
+
+Revision History
+
+    Version 1, September 6, 2013
+        Initial draft (Neil Roberts)
+    Version 2, October 25, 2013
+        Added a note about more possible reasons for returning EGL_BAD_FORMAT.

--- a/index.php
+++ b/index.php
@@ -339,6 +339,10 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=135> <a href="extensions/NV/EGL_NV_stream_dma.txt">EGL_NV_stream_dma</a>
 </li>
+<li value=136> <a href="extensions/WL/EGL_WL_bind_wayland_display.txt">EGL_WL_bind_wayland_display</a>
+</li>
+<li value=137> <a href="extensions/WL/EGL_WL_create_wayland_buffer_from_image.txt">EGL_WL_create_wayland_buffer_from_image</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -699,4 +699,14 @@ extension EGL_NV_stream_dma {
     flags       public
     filename    extensions/NV/EGL_NV_stream_dma.txt
 }
-# Next free extension number: 136
+extension EGL_WL_bind_wayland_display {
+    number	136
+    flags	public
+    filename	extensions/WL/EGL_WL_bind_wayland_display.txt
+}
+extension EGL_WL_create_wayland_buffer_from_image {
+    number	137
+    flags	public
+    filename	extensions/WL/EGL_WL_create_wayland_buffer_from_image.txt
+}
+# Next free extension number: 138


### PR DESCRIPTION
These extensions were developed by the Wayland project several years
ago, but never proposed for inclusion in the primary Khronos repository.

Unfortunately this includes tokens which alias with already-defined
values for the EGL platform extensions. Downstream implementations also
offered non-standard typedefs (e.g. PFNEGLBINDWAYLANDDISPLAYWL instead
of PFNEGLBINDWAYLANDDISPLAYWLPROC) which will have to be accounted for
in those implementations.