### PR TITLE
Add support for Fuchsia platform.

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -146,6 +146,12 @@ typedef void              *EGLNativeDisplayType;
 typedef khronos_uintptr_t  EGLNativePixmapType;
 typedef khronos_uintptr_t  EGLNativeWindowType;
 
+#elif defined(__Fuchsia__)
+
+typedef void              *EGLNativeDisplayType;
+typedef khronos_uintptr_t  EGLNativePixmapType;
+typedef khronos_uintptr_t  EGLNativeWindowType;
+
 #else
 #error "Platform not recognized"
 #endif


### PR DESCRIPTION
This patch only ensures that EGLNative{Display,Pixmap,Window}Type
are defined to adequately-sized generic types. There is no native
EGL support on Fuchsia, which only provides Vulkan APIs.

However, this definition opens the door to porting libraries like
ANGLE or SwiftShader to the platform. For example, see:

  https://swiftshader-review.googlesource.com/c/SwiftShader/+/38488