### PR TITLE
Example of defining backwards-compatibility names 

### DIFF
--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: cb927ca98d $ on $Git commit date: 2019-08-08 01:05:38 -0700 $
+** Khronos $Git commit SHA1: de3a5e867d $ on $Git commit date: 2019-10-12 05:44:43 -0700 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20190808
+#define EGL_EGLEXT_VERSION 20191212
 
 /* Generated C header for:
  * API: egl
@@ -202,6 +202,8 @@ EGLAPI EGLBoolean EGLAPIENTRY eglGetSyncAttribKHR (EGLDisplay dpy, EGLSyncKHR sy
 
 #ifndef EGL_KHR_image
 #define EGL_KHR_image 1
+#define PGNEGLBINDWAYLANDDISPLAYWL PFNEGLCREATEIMAGEKHRPROC
+#define PFNEGLBINDWAYLANDDISPLAYWLPROC PFNEGLDESTROYIMAGEKHRPROC
 typedef void *EGLImageKHR;
 #define EGL_NATIVE_PIXMAP_KHR             0x30B0
 #define EGL_NO_IMAGE_KHR                  EGL_CAST(EGLImageKHR,0)

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -90,6 +90,12 @@
     EGLint iStride;
 };</type>
         <type>typedef void (<apientry/> *<name>EGLDEBUGPROCKHR</name>)(EGLenum error,const char *command,EGLint messageType,EGLLabelKHR threadLabel,EGLLabelKHR objectLabel,const char* message);</type>
+            <!-- These are aliases of EGL function pointer types, as an
+                 example for #95. It would probably be better to use
+                 typedefs, but unfortunately the way output elements in an
+                 extension interface are sorted prevents that. -->
+        <type>#define <name>PGNEGLBINDWAYLANDDISPLAYWL</name> PFNEGLCREATEIMAGEKHRPROC</type>
+        <type>#define <name>PFNEGLBINDWAYLANDDISPLAYWLPROC</name> PFNEGLDESTROYIMAGEKHRPROC</type>
     </types>
 
     <!-- SECTION: EGL enumerant (token) definitions. -->
@@ -2724,6 +2730,9 @@
                 <enum name="EGL_NO_IMAGE_KHR"/>
                 <command name="eglCreateImageKHR"/>
                 <command name="eglDestroyImageKHR"/>
+                    <!-- Backwards-compatibility aliases of function pointer types -->
+                <type name="PGNEGLBINDWAYLANDDISPLAYWL"/>
+                <type name="PFNEGLBINDWAYLANDDISPLAYWLPROC"/>
             </require>
         </extension>
         <extension name="EGL_KHR_image_base" supported="egl">


### PR DESCRIPTION
for EGL function pointer types in egl.xml. Unfortunately this approach uses #defines
rather than typedefs, due to constraints in the generator scripts, but it should work OK. This example would have to be converted into the right extension / names for the branch underlying #95 - this PR exists only as an example.