### PR TITLE
Don't let KHRONOS_STATIC affect the calling convention

### DIFF
--- a/api/KHR/khrplatform.h
+++ b/api/KHR/khrplatform.h
@@ -119,7 +119,7 @@
  * This follows the return type of the function  and precedes the function
  * name in the function prototype.
  */
-#if defined(_WIN32) && !defined(_WIN32_WCE) && !defined(KHRONOS_STATIC)
+#if defined(_WIN32) && !defined(_WIN32_WCE) && !defined(__SCITECH_SNAP__)
     /* Win32 but not WinCE */
 #   define KHRONOS_APIENTRY __stdcall
 #else


### PR DESCRIPTION
When intending to link statically, we should leave out
__declspec(dllimport), but the calling convention (__stdcall) should
still be the same.

This reverts parts of commit 94ba8ee876206364cf45a9bc08b8db5a52cb9543,
making the exception to __stdcall specific to __SCITECH_SNAP__ again
as it was before.