### PR TITLE
extensions: Add EGL_EXT_device_query_name.

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -33,7 +33,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: ad06e1c38e $ on $Git commit date: 2020-04-09 18:40:05 +0200 $
+** Khronos $Git commit SHA1: f636b23410 $ on $Git commit date: 2020-05-29 19:32:12 +0300 $
 */
 
 #include <EGL/eglplatform.h>
@@ -42,7 +42,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20200505 */
+/* Generated on date 20200616 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -33,12 +33,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: ad06e1c38e $ on $Git commit date: 2020-04-09 18:40:05 +0200 $
+** Khronos $Git commit SHA1: f636b23410 $ on $Git commit date: 2020-05-29 19:32:12 +0300 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20200505
+#define EGL_EGLEXT_VERSION 20200616
 
 /* Generated C header for:
  * API: egl
@@ -706,6 +706,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint a
 #ifndef EGL_EXT_device_query
 #define EGL_EXT_device_query 1
 #endif /* EGL_EXT_device_query */
+
+#ifndef EGL_EXT_device_query_name
+#define EGL_EXT_device_query_name 1
+#define EGL_RENDERER_EXT                  0x335F
+#endif /* EGL_EXT_device_query_name */
 
 #ifndef EGL_EXT_gl_colorspace_bt2020_linear
 #define EGL_EXT_gl_colorspace_bt2020_linear 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -870,7 +870,8 @@
         <enum value="0x3352" name="EGL_TRACK_REFERENCES_KHR"/>
             <unused start="0x3353" end="0x3356"/>
         <enum value="0x3357" name="EGL_CONTEXT_PRIORITY_REALTIME_NV"/>
-            <unused start="0x3358" end="0x335F"/>
+            <unused start="0x3358" end="0x335E"/>
+        <enum value="0x335F" name="EGL_RENDERER_EXT"/>
         <enum value="0x3360" name="EGL_CTA861_3_MAX_CONTENT_LIGHT_LEVEL_EXT"/>
         <enum value="0x3361" name="EGL_CTA861_3_MAX_FRAME_AVERAGE_LEVEL_EXT"/>
         <enum value="0x3362" name="EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT"/>
@@ -3408,6 +3409,11 @@
             <require>
                 <enum name="EGL_COLOR_COMPONENT_TYPE_UNSIGNED_INTEGER_ARM"/>
                 <enum name="EGL_COLOR_COMPONENT_TYPE_INTEGER_ARM"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_device_query_name" supported="egl">
+            <require>
+                <enum name="EGL_RENDERER_EXT"/>
             </require>
         </extension>
     </extensions>

--- a/extensions/EXT/EGL_EXT_device_query_name.txt
+++ b/extensions/EXT/EGL_EXT_device_query_name.txt
@@ -1,0 +1,104 @@
+Name
+
+    EXT_device_query_name
+
+Name Strings
+
+    EGL_EXT_device_query_name
+
+Contributors
+
+    Kyle Brenneman,  NVIDIA  (kbrenneman 'at' nvidia.com)
+    Daniel Kartch, NVIDIA (dkartch 'at' nvidia.com)
+
+Contact
+
+    Kyle Brenneman,  NVIDIA  (kbrenneman 'at' nvidia.com)
+
+Status
+
+    Complete
+
+Version
+
+    Version 1 - June 12, 2020
+
+Number
+
+    EGL Extension #140
+
+Extension Type
+
+    EGL device extension
+
+Dependencies
+
+    Written based on the wording of the EGL 1.5 specification.
+
+    EGL_EXT_device_query is required.
+
+Overview
+
+    The EGL_EXT_device_enumeration and EGL_EXT_device_query extensions
+    provide a list of devices and a list of extensions, but lacks a way
+    to find a name for a device that an application can present to a
+    user.
+
+    This extension adds two new strings that an application can query to
+    find human-readable names.
+
+New Types
+
+    None
+
+New Functions
+
+    None
+
+New Tokens
+
+    Accepted by the <name> parameter of eglQueryDeviceStringEXT:
+
+        EGL_RENDERER_EXT                0x335E
+
+New Device Queries
+
+    eglQueryDeviceStringEXT accepts two new attributes.
+
+    EGL_VENDOR and EGL_RENDERER_EXT return a human-readable name for the
+    vendor and device, respectively.
+
+    The format of the EGL_VENDOR and EGL_RENDERER strings is
+    implementation-dependent.
+
+    The EGL_VENDOR string for an EGLDeviceEXT is not required to match
+    the EGL_VENDOR string for an EGLDisplay or the GL_VENDOR string for
+    a context. Similarly, the EGL_RENDERER string is not required to
+    match the GL_RENDERER string for a context.
+
+Issues
+
+    1.  Do we need a device query, instead of just creating an
+        EGLDisplay and calling eglQueryString?
+
+        RESOLVED: Yes, a device-level query is useful, because some
+        devices might not be usable with EGL_EXT_platform_device. This
+        is especially true on systems where different devices are
+        handled by different drivers.
+
+    2.  If an application creates an EGLDisplay from an EGLDevice,
+        are the EGL_VENDOR strings required to match?
+
+        RESOLVED: No. Some implementations might not load a driver until
+        eglInitialize, and so might have a different or more specific
+        EGL_VENDOR string associated with an EGLDisplay than with an
+        EGLDeviceEXT. In addition, an implementation might select a
+        driver to use based on other parameters in
+        eglGetPlatformDisplay.
+
+Revision History
+
+    #1 (June 12, 2020) Kyle Brenneman
+
+        - Initial draft
+

--- a/index.php
+++ b/index.php
@@ -345,6 +345,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=139> <a href="extensions/NV/EGL_NV_stream_consumer_eglimage.txt">EGL_NV_stream_consumer_eglimage</a>
 </li>
+<li value=140> <a href="extensions/EXT/EGL_EXT_device_query_name.txt">EGL_EXT_device_query_name</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -719,4 +719,9 @@ extension EGL_NV_stream_consumer_eglimage {
     flags       public
     filename    extensions/NV/EGL_NV_stream_consumer_eglimage.txt
 }
-# Next free extension number: 140
+extension EGL_NV_stream_consumer_eglimage {
+    number      140
+    flags       public
+    filename    extensions/EXT/EGL_EXT_device_query_name.txt
+}
+# Next free extension number: 141


### PR DESCRIPTION
This is a proposal for a simple EGL extension to let an application query a vendor name and device name from an `EGLDeviceEXT` handle.

It just adds `EGL_VENDOR` and a new `EGL_RENDERER_EXT` as valid queries for `eglQueryDeviceStringEXT`.