### PR TITLE
Switch to Apache 2.0 license on headers, and use SPDX license identifiers

### DIFF
--- a/api/1.0/EGL/egl.h
+++ b/api/1.0/EGL/egl.h
@@ -1,3 +1,6 @@
+/* Copyright 2006-2020 The Khronos Group Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 /* Sketchy version of egl.h (really only for reserving
  * enumerant values to EGL tokens and sanity checking
  * prototypes).

--- a/api/1.1/EGL/egl.h
+++ b/api/1.1/EGL/egl.h
@@ -1,39 +1,9 @@
+/* Copyright 2006-2020 The Khronos Group Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef __egl_h_
 #define __egl_h_
-
-/*
-** License Applicability. Except to the extent portions of this file are
-** made subject to an alternative license as permitted in the SGI Free
-** Software License B, Version 1.0 (the "License"), the contents of this
-** file are subject only to the provisions of the License. You may not use
-** this file except in compliance with the License. You may obtain a copy
-** of the License at Silicon Graphics, Inc., attn: Legal Services, 1600
-** Amphitheatre Parkway, Mountain View, CA 94043-1351, or at:
-**
-** http://oss.sgi.com/projects/FreeB
-**
-** Note that, as provided in the License, the Software is distributed on an
-** "AS IS" basis, with ALL EXPRESS AND IMPLIED WARRANTIES AND CONDITIONS
-** DISCLAIMED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTIES AND
-** CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A
-** PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
-**
-** Original Code. The Original Code is: OpenGL Sample Implementation,
-** Version 1.2.1, released January 26, 2000, developed by Silicon Graphics,
-** Inc. The Original Code is Copyright (c) 1991-2004 Silicon Graphics, Inc.
-** Copyright in any portions created by third parties is as indicated
-** elsewhere herein. All Rights Reserved.
-**
-** Additional Notice Provisions: The application programming interfaces
-** established by SGI in conjunction with the Original Code are The
-** OpenGL(R) Graphics System: A Specification (Version 1.2.1), released
-** April 1, 1999; The OpenGL(R) Graphics System Utility Library (Version
-** 1.3), released November 4, 1998; and OpenGL(R) Graphics with the X
-** Window System(R) (Version 1.3), released October 19, 1998. This software
-** was created using the OpenGL(R) version 1.2.1 Sample Implementation
-** published by SGI, but has not been independently verified as being
-** compliant with the OpenGL(R) version 1.2.1 Specification.
-*/
 
 #include <GLES/gl.h>
 #include <GLES/egltypes.h>

--- a/api/1.2/EGL/egl.h
+++ b/api/1.2/EGL/egl.h
@@ -1,3 +1,7 @@
+/* Copyright 2006-2020 The Khronos Group Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* Reference egl.h for EGL 1.2
  * Last modified 2006/10/24
  */

--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -6,34 +6,15 @@ extern "C" {
 #endif
 
 /*
-** Copyright (c) 2013-2017 The Khronos Group Inc.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and/or associated documentation files (the
-** "Materials"), to deal in the Materials without restriction, including
-** without limitation the rights to use, copy, modify, merge, publish,
-** distribute, sublicense, and/or sell copies of the Materials, and to
-** permit persons to whom the Materials are furnished to do so, subject to
-** the following conditions:
-**
-** The above copyright notice and this permission notice shall be included
-** in all copies or substantial portions of the Materials.
-**
-** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-*/
+** Copyright 2013-2020 The Khronos Group Inc.
+** SPDX-License-Identifier: Apache-2.0
 /*
 ** This header is generated from the Khronos EGL XML API Registry.
 ** The current version of the Registry, generator scripts
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: ad06e1c38e $ on $Git commit date: 2020-04-09 18:40:05 +0200 $
+** Khronos $Git commit SHA1: d7ddb16e56 $ on $Git commit date: 2020-06-29 19:07:11 -0600 $
 */
 
 #include <EGL/eglplatform.h>
@@ -42,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20200505 */
+/* Generated on date 20200813 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -6,39 +6,20 @@ extern "C" {
 #endif
 
 /*
-** Copyright (c) 2013-2017 The Khronos Group Inc.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and/or associated documentation files (the
-** "Materials"), to deal in the Materials without restriction, including
-** without limitation the rights to use, copy, modify, merge, publish,
-** distribute, sublicense, and/or sell copies of the Materials, and to
-** permit persons to whom the Materials are furnished to do so, subject to
-** the following conditions:
-**
-** The above copyright notice and this permission notice shall be included
-** in all copies or substantial portions of the Materials.
-**
-** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-*/
+** Copyright 2013-2020 The Khronos Group Inc.
+** SPDX-License-Identifier: Apache-2.0
 /*
 ** This header is generated from the Khronos EGL XML API Registry.
 ** The current version of the Registry, generator scripts
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: ad06e1c38e $ on $Git commit date: 2020-04-09 18:40:05 +0200 $
+** Khronos $Git commit SHA1: d7ddb16e56 $ on $Git commit date: 2020-06-29 19:07:11 -0600 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20200505
+#define EGL_EGLEXT_VERSION 20200813
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -2,36 +2,17 @@
 #define __eglplatform_h_
 
 /*
-** Copyright (c) 2007-2016 The Khronos Group Inc.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and/or associated documentation files (the
-** "Materials"), to deal in the Materials without restriction, including
-** without limitation the rights to use, copy, modify, merge, publish,
-** distribute, sublicense, and/or sell copies of the Materials, and to
-** permit persons to whom the Materials are furnished to do so, subject to
-** the following conditions:
-**
-** The above copyright notice and this permission notice shall be included
-** in all copies or substantial portions of the Materials.
-**
-** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+** Copyright 2007-2020 The Khronos Group Inc.
+** SPDX-License-Identifier: Apache-2.0
 */
 
 /* Platform-specific types and definitions for egl.h
- * $Revision: 30994 $ on $Date: 2015-04-30 13:36:48 -0700 (Thu, 30 Apr 2015) $
  *
  * Adopters may modify khrplatform.h and this file to suit their platform.
  * You are encouraged to submit all modifications to the Khronos group so that
  * they can be included in future versions of this file.  Please submit changes
- * by sending them to the public Khronos Bugzilla (http://khronos.org/bugzilla)
- * by filing a bug against product "EGL" component "Registry".
+ * by filing an issue or pull request on the public Khronos EGL Registry, at
+ * https://www.github.com/KhronosGroup/EGL-Registry/
  */
 
 #include <KHR/khrplatform.h>

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,16 +1,5 @@
-# Copyright (c) 2013-2018 The Khronos Group Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2013-2020 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 # Generated headers
 EGLHEADERS = EGL/egl.h EGL/eglext.h

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1,27 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <!--
-    Copyright (c) 2013-2017 The Khronos Group Inc.
-
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and/or associated documentation files (the
-    "Materials"), to deal in the Materials without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Materials, and to
-    permit persons to whom the Materials are furnished to do so, subject to
-    the following conditions:
-
-    The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Materials.
-
-    THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-    MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-    -->
+    Copyright 2013-2020 The Khronos Group Inc.
+    SPDX-License-Identifier: Apache-2.0
+     -->
     <!--
     This file, egl.xml, is the EGL API Registry. The older ".spec" file
     format has been retired and will no longer be updated with new

--- a/api/egltest.c
+++ b/api/egltest.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2013-2020 The Khronos Group Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* Simple test that generated EGL headers compile with C and C++ */
 #include "EGL/egl.h"
 #include "EGL/eglext.h"

--- a/api/genheaders.py
+++ b/api/genheaders.py
@@ -1,18 +1,7 @@
 #!/usr/bin/python -i
 #
-# Copyright (c) 2013-2017 The Khronos Group Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2013-2020 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 import sys, time, pdb, string, cProfile
 from reg import *
@@ -81,27 +70,8 @@ glx13andLaterPat  = '1\.[3-9]'
 # Copyright text prefixing all headers (list of strings).
 prefixStrings = [
     '/*',
-    '** Copyright (c) 2013-2017 The Khronos Group Inc.',
-    '**',
-    '** Permission is hereby granted, free of charge, to any person obtaining a',
-    '** copy of this software and/or associated documentation files (the',
-    '** "Materials"), to deal in the Materials without restriction, including',
-    '** without limitation the rights to use, copy, modify, merge, publish,',
-    '** distribute, sublicense, and/or sell copies of the Materials, and to',
-    '** permit persons to whom the Materials are furnished to do so, subject to',
-    '** the following conditions:',
-    '**',
-    '** The above copyright notice and this permission notice shall be included',
-    '** in all copies or substantial portions of the Materials.',
-    '**',
-    '** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,',
-    '** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF',
-    '** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.',
-    '** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY',
-    '** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,',
-    '** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE',
-    '** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.',
-    '*/',
+    '** Copyright 2013-2020 The Khronos Group Inc.',
+    '** SPDX-' + 'License-Identifier: Apache-2.0',
     '/*',
     '** This header is generated from the Khronos EGL XML API Registry.',
     '** The current version of the Registry, generator scripts',

--- a/api/reg.py
+++ b/api/reg.py
@@ -1,18 +1,7 @@
 #!/usr/bin/python -i
 #
-# Copyright (c) 2013-2016 The Khronos Group Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2013-2020 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 import io,os,re,string,sys
 from lxml import etree

--- a/api/registry.rnc
+++ b/api/registry.rnc
@@ -1,23 +1,5 @@
-# Copyright (c) 2013-2017 The Khronos Group Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and/or associated documentation files (the
-# "Materials"), to deal in the Materials without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Materials, and to
-# permit persons to whom the Materials are furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Materials.
-#
-# THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-# MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+# Copyright 2013-2020 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 # Relax NG schema for Khronos Registry XML
 # See https://www.github.com/KhronosGroup/EGL-Registry

--- a/registry.tcl
+++ b/registry.tcl
@@ -1,3 +1,6 @@
+# Copyright 2006-2020 The Khronos Group Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 # registry.tcl
 #
 # This is a simple human-readable database defining the EGL extension
@@ -700,19 +703,19 @@ extension EGL_NV_stream_dma {
     filename    extensions/NV/EGL_NV_stream_dma.txt
 }
 extension EGL_WL_bind_wayland_display {
-    number	136
-    flags	public
-    filename	extensions/WL/EGL_WL_bind_wayland_display.txt
+    number      136
+    flags       public
+    filename    extensions/WL/EGL_WL_bind_wayland_display.txt
 }
 extension EGL_WL_create_wayland_buffer_from_image {
-    number	137
-    flags	public
-    filename	extensions/WL/EGL_WL_create_wayland_buffer_from_image.txt
+    number      137
+    flags       public
+    filename    extensions/WL/EGL_WL_create_wayland_buffer_from_image.txt
 }
 extension EGL_ARM_image_format {
-    number	138
-    flags	public
-    filename	extensions/ARM/EGL_ARM_image_format.txt
+    number      138
+    flags       public
+    filename    extensions/ARM/EGL_ARM_image_format.txt
 }
 extension EGL_NV_stream_consumer_eglimage {
     number      139


### PR DESCRIPTION
This migrates the format of license headers to use SPDX license identifiers, instead of the full Apache license text. It is otherwise a no-op (although there is a small possibility someone would complain about changing eglplatform.h to Apache 2.0, in which case we'd just change it to Apache 2.0 OR MIT).

I probably won't try and do full REUSE license checker compliance on this repository, given the many extension specs we don't own copyrights or licenses on, and can't change, but changing the headers has downstream benefits.