### PR TITLE
Fixed comment in egl.h and eglext.h headers

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -8,7 +8,7 @@ extern "C" {
 /*
 ** Copyright 2013-2020 The Khronos Group Inc.
 ** SPDX-License-Identifier: Apache-2.0
-/*
+**
 ** This header is generated from the Khronos EGL XML API Registry.
 ** The current version of the Registry, generator scripts
 ** used to make the header, and the header can be found at

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -8,7 +8,7 @@ extern "C" {
 /*
 ** Copyright 2013-2020 The Khronos Group Inc.
 ** SPDX-License-Identifier: Apache-2.0
-/*
+**
 ** This header is generated from the Khronos EGL XML API Registry.
 ** The current version of the Registry, generator scripts
 ** used to make the header, and the header can be found at

--- a/api/genheaders.py
+++ b/api/genheaders.py
@@ -72,7 +72,7 @@ prefixStrings = [
     '/*',
     '** Copyright 2013-2020 The Khronos Group Inc.',
     '** SPDX-' + 'License-Identifier: Apache-2.0',
-    '/*',
+    '**',
     '** This header is generated from the Khronos EGL XML API Registry.',
     '** The current version of the Registry, generator scripts',
     '** used to make the header, and the header can be found at',


### PR DESCRIPTION
This avoids a comment warning during build.

Nicolas Caramelli