### PR TITLE
Fix an enum value in the EGL_EXT_device_query_name spec

### DIFF
--- a/extensions/EXT/EGL_EXT_device_query_name.txt
+++ b/extensions/EXT/EGL_EXT_device_query_name.txt
@@ -59,7 +59,7 @@ New Tokens
 
     Accepted by the <name> parameter of eglQueryDeviceStringEXT:
 
-        EGL_RENDERER_EXT                0x335E
+        EGL_RENDERER_EXT                0x335F
 
 New Device Queries
 


### PR DESCRIPTION
This fixes a typo in the EGL_EXT_device_query_name spec. The EGL_RENDERER_EXT enum is supposed to have the value 0x335F, but I typed in 0x335E when writing up the spec.

egl.xml (and eglext.h) have the correct value.