### PR TITLE
extensions: Add EGL_EXT_config_select_group

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -14,7 +14,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: e8baa0bf39 $ on $Git commit date: 2021-04-26 17:56:26 -0600 $
+** Khronos $Git commit SHA1: 9581d004ff $ on $Git commit date: 2021-04-06 15:53:59 +0200 $
 */
 
 #include <EGL/eglplatform.h>
@@ -23,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20210604 */
+/* Generated on date 20210802 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -651,6 +651,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglCompositorSwapPolicyEXT (EGLint external_win_id
 #endif
 #endif /* EGL_EXT_compositor */
 
+#ifndef EGL_EXT_config_select_group
+#define EGL_EXT_config_select_group 1
+#define EGL_CONFIG_SELECT_GROUP_EXT       0x34C0
+#endif /* EGL_EXT_config_select_group */
+
 #ifndef EGL_EXT_create_context_robustness
 #define EGL_EXT_create_context_robustness 1
 #define EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT 0x30BF

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1030,7 +1030,8 @@
     </enums>
 
     <enums namespace="EGL" start="0x34C0" end="0x34CF" vendor="EXT" comment="Reserved for Robert Mader (PR 124)">
-        <unused start="0x34C0" end="0x34CF"/>
+        <enum value="0x34C0" name="EGL_CONFIG_SELECT_GROUP_EXT"/>
+            <unused start="0x34C1" end="0x34CF"/>
     </enums>
 
 <!-- Please remember that new enumerant allocations must be obtained by
@@ -2395,6 +2396,11 @@
                 <enum name="EGL_SYNC_CLIENT_SIGNAL_EXT"/>
                 <command name="eglClientSignalSyncEXT"/>
             </require>
+        </extension>
+        <extension name="EGL_EXT_config_select_group" supported="egl">
+          <require>
+                <enum name="EGL_CONFIG_SELECT_GROUP_EXT"/>
+          </require>
         </extension>
         <extension name="EGL_EXT_create_context_robustness" supported="egl">
             <require>

--- a/extensions/EXT/EGL_EXT_config_select_group.txt
+++ b/extensions/EXT/EGL_EXT_config_select_group.txt
@@ -1,0 +1,111 @@
+Name
+
+    EGL_EXT_config_select_group
+
+Name Strings
+
+    EGL_EXT_config_select_group
+
+Contributors
+
+    Hal Gentz <zegentzy@protonmail.com>
+    Adam Jackson <ajax@redhat.com>
+    Robert Mader <robert.mader@posteo.de>
+
+Contacts
+
+    Hal Gentz <zegentzy@protonmail.com>
+
+Status
+
+    Draft
+
+Version
+
+    Version 4, 2021-06-24
+
+Number
+
+    EGL Extension #145
+
+Extension Type
+
+    EGL client extension
+
+Dependencies
+
+    This extension is written against the wording of the 2014.08.27 revision
+    of the EGL 1.5 Specification.
+
+Overview
+
+    This extension provides a mechanism to lower the config selection priority
+    of the configs returned by eglChooseConfig. A new config attribute is
+    introduced, providing a way for the implementation to group configs into
+    different config selection categories.  The config selection priorities of
+    all the configs in one category may be higher or lower than the ones in
+    other categories.  The config selection priorities in one category follow
+    the rules of eglChooseConfig. See also GLX_SGIX_visual_select_group.
+
+New Types
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    Accepted as a new EGLConfig attribute:
+
+        EGL_CONFIG_SELECT_GROUP_EXT                0x34C0
+
+Additions to the EGL 1.5 Specification
+
+    In section 3.4 "Configuration Management", under the "Buffer Descriptions
+    and Attributes" heading, append to table 3.1 the following:
+
+    "EGL_CONFIG_SELECT_GROUP_EXT | integer | the config select group"
+
+    In section 3.4 "Configuration Management", under the "Other EGLConfig
+    Attribute Descriptions" heading, append to the end the following:
+
+    "The attribute EGL_CONFIG_SELECT_GROUP_EXT is used to specify the config
+    selection category of the config. Configs in the i-th category have a higher
+    config selection priority than those found in the (i+1)-th category.
+
+    "The attribute EGL_CONFIG_SELECT_GROUP_EXT is used by the implementation to
+    override the default sorting rules, by collecting configurations into
+    groups. It is not accepted by the <attrib_list> parameter of
+    eglChooseConfig, but it is accepted as the <attribute> in
+    eglGetConfigAtrrib."
+
+    In section 3.4 "Configuration Management", under the "Sorting of EGLConfigs"
+    heading, append to table 3.4 the following:
+
+    "EGL_CONFIG_SELECT_GROUP_EXT | 0 | Ignore | Smaller | 0"
+
+    In section 3.4 "Configuration Management", under the "Sorting of EGLConfigs"
+    heading, append before the list entry which starts with "1. Special: by
+    EGL_CONFIG_CAVEAT" the following entry:
+
+    "0. Smaller EGL_CONFIG_SELECT_GROUP_EXT."
+
+Issues
+
+    None
+
+Revision History
+
+    Version 4, 2021-06-24 (Robert Mader)
+        - Moved to EXT, changed enum value to 0x34C0.
+
+    Version 3, 2020-04-06 (Robert Mader)
+        - Changed enum value to 0x31DF, added contributors.
+
+    Version 2, 2019-07-11 (Hal Gentz)
+        - Resolved issues pointed out by Adam Jackson.
+
+    Version 1, 2019-06-21 (Hal Gentz)
+        - Initial draft

--- a/registry.tcl
+++ b/registry.tcl
@@ -747,4 +747,9 @@ extension EGL_EXT_device_drm_render_node {
     flags       public
     filename    extensions/EXT/EGL_EXT_device_drm_render_node.txt
 }
-# Next free extension number: 145
+extension EGL_EXT_config_select_group {
+    number      145
+    flags       public
+    filename    extensions/EXT/EGL_EXT_config_select_group.txt
+}
+# Next free extension number: 146


### PR DESCRIPTION
This extension will be used to allow picking EGL configs that
are handled as transparent by X11 compositors.

See also:
 - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/9989
 - https://bugzilla.mozilla.org/show_bug.cgi?id=1702546