### PR TITLE
extensions: Add EGL_EXT_device_drm_render_node

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -14,7 +14,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 5a9a7e3fcb $ on $Git commit date: 2020-08-24 11:05:32 -0700 $
+** Khronos $Git commit SHA1: e8baa0bf39 $ on $Git commit date: 2021-04-26 17:56:26 -0600 $
 */
 
 #include <EGL/eglplatform.h>
@@ -23,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20201001 */
+/* Generated on date 20210604 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 59522adade $ on $Git commit date: 2021-02-02 11:09:11 -0700 $
+** Khronos $Git commit SHA1: e8baa0bf39 $ on $Git commit date: 2021-04-26 17:56:26 -0600 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20210419
+#define EGL_EGLEXT_VERSION 20210604
 
 /* Generated C header for:
  * API: egl
@@ -682,6 +682,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint a
 #define EGL_DRM_DEVICE_FILE_EXT           0x3233
 #define EGL_DRM_MASTER_FD_EXT             0x333C
 #endif /* EGL_EXT_device_drm */
+
+#ifndef EGL_EXT_device_drm_render_node
+#define EGL_EXT_device_drm_render_node 1
+#define EGL_DRM_RENDER_NODE_FILE_EXT      0x3377
+#endif /* EGL_EXT_device_drm_render_node */
 
 #ifndef EGL_EXT_device_enumeration
 #define EGL_EXT_device_enumeration 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -881,7 +881,8 @@
         <enum value="0x3374" name="EGL_STREAM_IMAGE_ADD_NV"/>
         <enum value="0x3375" name="EGL_STREAM_IMAGE_REMOVE_NV"/>
         <enum value="0x3376" name="EGL_STREAM_IMAGE_AVAILABLE_NV"/>
-            <unused start="0x3377" end="0x339F"/>
+        <enum value="0x3377" name="EGL_DRM_RENDER_NODE_FILE_EXT"/>
+            <unused start="0x3378" end="0x339F"/>
     </enums>
 
     <enums namespace="EGL" start="0x33A0" end="0x33AF" vendor="ANGLE" comment="Reserved for Shannon Woods (Bug 13175)">
@@ -3425,6 +3426,11 @@
                 <enum name="EGL_DEVICE_UUID_EXT"/>
                 <enum name="EGL_DRIVER_UUID_EXT"/>
                 <enum name="EGL_DRIVER_NAME_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_device_drm_render_node" supported="egl">
+            <require>
+                <enum name="EGL_DRM_RENDER_NODE_FILE_EXT"/>
             </require>
         </extension>
     </extensions>

--- a/extensions/EXT/EGL_EXT_device_drm_render_node.txt
+++ b/extensions/EXT/EGL_EXT_device_drm_render_node.txt
@@ -9,6 +9,8 @@ Name Strings
 Contributors
 
     James Jones
+    Simon Ser
+    Daniel Stone
 
 Contacts
 
@@ -41,10 +43,12 @@ Dependencies
 Overview
 
     The EGL_EXT_device_drm extension provided a method for applications
-    to query the primary DRM device node file associated with a given
-    EGLDeviceEXT object, but many cards also or exclusively have an
-    associated render node DRM device node. This extension enables
-    querying the render node file path of an EGLDeviceEXT object.
+    to query the DRM device node file associated with a given
+    EGLDeviceEXT object. However, it was not clear whether it referred to
+    the primary or render device node. This extension adds an enum to
+    refer explicitly to the render device node and defines the existing
+    EGL_DRM_DEVICE_FILE_EXT as explicitly refering to the primary device
+    node.
 
 New Types
 
@@ -69,21 +73,34 @@ Changes to section 3.2 (Devices)
     EGLDeviceEXT, call eglQueryDeviceStringEXT with <name> set to
     EGL_DRM_RENDER_NODE_FILE_EXT. The function will return a pointer to
     a string containing the name of the device file (e.g.
-    "/dev/dri/renderDN")."
+    "/dev/dri/renderDN"), or NULL if the device has no associated DRM
+    render node."
 
-    If EGL_EXT_device_drm is present, modify the the first sentence of
-    the paragraph in the same section describing EGL_DRM_DEVICE_FILE_EXT
-    to read:
+    If EGL_EXT_device_drm is present, append the following to the
+    paragraph in the same section describing EGL_DRM_DEVICE_FILE_EXT:
 
-    "To obtain a DRM device file for the primary node associated with an
-    EGLDeviceEXT, call eglQueryDeviceStringEXT with <name> set to
-    EGL_DRM_DEVICE_FILE_EXT."
+    "If the EGL_EXT_device_drm_render_node extension is supported, the
+    value returned will refer to a primary device node, and will be NULL
+    if the device has no associated DRM primary node. If
+    EGL_EXT_device_drm_render_node is not supported, the value returned
+    will refer to a primary device node if there exists one associated
+    with the device. Otherwise, it will refer to a render device node if
+    there exists one associated with the device. If neither exists, NULL
+    is returned."
 
 Issues
 
-    None.
+    1)  Should this extension clarify that EGL_DRM_DEVICE_FILE_EXT refers
+        only to primary device nodes?
+
+        RESOLVED: Yes, but only when this extension is supported. Existing
+        implementations return render node paths for that string when no
+        suitable primary node is available.
 
 Revision History:
+
+    #2  (June 8th, 2021) James Jones
+        - Added issue #1 and related spec changes.
 
     #1  (June 4th, 2021) James Jones
         - Initial draft.

--- a/extensions/EXT/EGL_EXT_device_drm_render_node.txt
+++ b/extensions/EXT/EGL_EXT_device_drm_render_node.txt
@@ -1,0 +1,89 @@
+Name
+
+    EXT_device_drm_render_node
+
+Name Strings
+
+    EXT_device_drm_render_node
+
+Contributors
+
+    James Jones
+
+Contacts
+
+    James Jones, NVIDIA (jajones 'at' nvidia.com)
+
+Status
+
+    Draft
+
+Version
+
+    Version 1 - June 4th, 2021
+
+Number
+
+    EGL Extension #144
+
+Extension Type
+
+    EGL device extension
+
+Dependencies
+
+    Written based on the wording of the EGL 1.5 specification.
+
+    EGL_EXT_device_query is required.
+
+    EGL_EXT_device_drm interacts with this extension.
+
+Overview
+
+    The EGL_EXT_device_drm extension provided a method for applications
+    to query the primary DRM device node file associated with a given
+    EGLDeviceEXT object, but many cards also or exclusively have an
+    associated render node DRM device node. This extension enables
+    querying the render node file path of an EGLDeviceEXT object.
+
+New Types
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    Accepted as the <name> parameter of eglQueryDeviceStringEXT
+
+        EGL_DRM_RENDER_NODE_FILE_EXT            0x3377
+
+Changes to section 3.2 (Devices)
+
+    Add the following paragraph to the description of
+    eglQueryDeviceStringEXT:
+
+    "To obtain a DRM device file for the render node associated with an
+    EGLDeviceEXT, call eglQueryDeviceStringEXT with <name> set to
+    EGL_DRM_RENDER_NODE_FILE_EXT. The function will return a pointer to
+    a string containing the name of the device file (e.g.
+    "/dev/dri/renderDN")."
+
+    If EGL_EXT_device_drm is present, modify the the first sentence of
+    the paragraph in the same section describing EGL_DRM_DEVICE_FILE_EXT
+    to read:
+
+    "To obtain a DRM device file for the primary node associated with an
+    EGLDeviceEXT, call eglQueryDeviceStringEXT with <name> set to
+    EGL_DRM_DEVICE_FILE_EXT."
+
+Issues
+
+    None.
+
+Revision History:
+
+    #1  (June 4th, 2021) James Jones
+        - Initial draft.

--- a/index.php
+++ b/index.php
@@ -353,6 +353,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=143> <a href="extensions/EXT/EGL_EXT_device_persistent_id.txt">EGL_EXT_device_persistent_id</a>
 </li>
+<li value=144> <a href="extensions/EXT/EGL_EXT_device_drm_render_node.txt">EGL_EXT_device_drm_render_node</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -742,4 +742,9 @@ extension EGL_EXT_device_persistent_id {
     flags       public
     filename    extensions/EXT/EGL_EXT_device_persistent_id.txt
 }
-# Next free extension number: 144
+extension EGL_EXT_device_drm_render_node {
+    number      144
+    flags       public
+    filename    extensions/EXT/EGL_EXT_device_drm_render_node.txt
+}
+# Next free extension number: 145


### PR DESCRIPTION
From the spec overview:

The EGL_EXT_device_drm extension provided a method for applications to query the primary DRM device node file associated with a given EGLDeviceEXT object, but many cards also or exclusively have an associated render node DRM device node. This extension enables querying the render node file path of an EGLDeviceEXT object.