### PR TITLE
Don't use Xlib headers by default

### DIFF
--- a/api/EGL/eglplatform.h
+++ b/api/EGL/eglplatform.h
@@ -103,13 +103,7 @@ typedef intptr_t EGLNativeDisplayType;
 typedef intptr_t EGLNativePixmapType;
 typedef intptr_t EGLNativeWindowType;
 
-#elif defined(__unix__) && defined(EGL_NO_X11)
-
-typedef void             *EGLNativeDisplayType;
-typedef khronos_uintptr_t EGLNativePixmapType;
-typedef khronos_uintptr_t EGLNativeWindowType;
-
-#elif defined(__unix__) || defined(USE_X11)
+#elif defined(USE_X11)
 
 /* X11 (tentative)  */
 #include <X11/Xlib.h>
@@ -118,6 +112,12 @@ typedef khronos_uintptr_t EGLNativeWindowType;
 typedef Display *EGLNativeDisplayType;
 typedef Pixmap   EGLNativePixmapType;
 typedef Window   EGLNativeWindowType;
+
+#elif defined(__unix__)
+
+typedef void             *EGLNativeDisplayType;
+typedef khronos_uintptr_t EGLNativePixmapType;
+typedef khronos_uintptr_t EGLNativeWindowType;
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
This changes eglplatform.h so that it'll use the `EGL_NO_X11` typedefs by default.

This has come up a couple times in libglvnd bug reports, where applications that use EGL but not X11 don't build on systems where the Xlib headers aren't installed. The `EGL_NO_X11` macro can fix that, but adding that to every broken app out there is a tall order, and adding it to libglvnd's pkg-config files seems like a crude workaround at best.

This change should be pretty safe, I think. Applications that currently pass a `Display *` value to eglGetDisplay will still build, because you can always pass a `Display *` to a `void *`. `EGLNativePixmapType` and `EGLNativeWindowType` won't change at all, because in both the Xlib and non-Xlib cases, they're typedefs for `unsigned long`.

Existing calls to eglQueryNativeDisplayNV could break, but I'd expect those to be relatively uncommon, and would just need a trivial typecast to fix. Alternately, you can still define `USE_X11` to get the current behavior.