### PR TITLE
extensions: add EGL_EXT_present_opaque

### DIFF
--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -904,6 +904,11 @@ EGLAPI EGLSurface EGLAPIENTRY eglCreatePlatformPixmapSurfaceEXT (EGLDisplay dpy,
 #define EGL_PLATFORM_XCB_SCREEN_EXT       0x31DE
 #endif /* EGL_EXT_platform_xcb */
 
+#ifndef EGL_EXT_present_opaque
+#define EGL_EXT_present_opaque 1
+#define EGL_PRESENT_OPAQUE_EXT            0x31DF
+#endif /* EGL_EXT_present_opaque */
+
 #ifndef EGL_EXT_protected_content
 #define EGL_EXT_protected_content 1
 #define EGL_PROTECTED_CONTENT_EXT         0x32C0

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -575,7 +575,7 @@
         <enum value="0x31DC" name="EGL_PLATFORM_XCB_EXT"/>
         <enum value="0x31DD" name="EGL_PLATFORM_SURFACELESS_MESA"/>
         <enum value="0x31DE" name="EGL_PLATFORM_XCB_SCREEN_EXT"/>
-            <unused start="0x31DF" end="0x31DF"/>
+        <enum value="0x31DF" name="EGL_PRESENT_OPAQUE_EXT"/>
     </enums>
 
     <!-- Due to an oversight in development, these enums alias the above MESA
@@ -2602,6 +2602,11 @@
             <require>
                 <enum name="EGL_PLATFORM_XCB_EXT"/>
                 <enum name="EGL_PLATFORM_XCB_SCREEN_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_present_opaque" supported="egl">
+            <require>
+                <enum name="EGL_PRESENT_OPAQUE_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_protected_content" supported="egl">

--- a/extensions/EXT/EGL_EXT_present_opaque.txt
+++ b/extensions/EXT/EGL_EXT_present_opaque.txt
@@ -1,0 +1,113 @@
+Name
+
+    EXT_present_opaque
+
+Name Strings
+
+    EGL_EXT_present_opaque
+
+Contributors
+
+    Eric Engestrom
+
+Contacts
+
+    Eric Engestrom (eric 'at' engestrom.ch)
+
+IP Status
+
+    No known IP claims.
+
+Status
+
+    Draft
+
+Version
+
+    #1, August 8, 2021
+
+Number
+
+    EGL Extension #146
+
+Extension Type
+
+    EGL display extension
+
+Dependencies
+
+    Requires EGL 1.4 and EGL_KHR_image_base extension
+
+    This extension is written against the wording of the EGL 1.4
+    specification, and EGL_KHR_image_base version 6.
+
+Overview
+
+    This extension adds a new EGL surface attribute EGL_PRESENT_OPAQUE_EXT
+    to indicate that the surface should be presented as opaque,
+    disregarding any alpha channel if present.
+    If surface attribute EGL_PRESENT_OPAQUE_EXT is EGL_TRUE, then the
+    surface will be presented as opaque.
+
+New Types
+
+    None
+
+New Procedures and Functions
+
+    None
+
+New Tokens
+
+    New EGLSurface attribute name:
+
+        EGL_PRESENT_OPAQUE_EXT                  0x31DF
+
+
+Additions to Chapter 3 of the EGL 1.4 Specification (Rendering Surfaces)
+
+    Change the second paragraph in section 3.5 on p. 28 (describing
+    eglCreateWindowSurface):
+
+        "Attributes that can be specified in attrib list include EGL_RENDER_BUFFER,
+        EGL_PRESENT_OPAQUE_EXT, EGL_VG_COLORSPACE, and EGL_VG_ALPHA_FORMAT."
+
+    Add the following paragraph in section 3.5 on p. 28 before
+    "EGL_VG_COLORSPACE specifies the color space used by OpenVG"
+    (describing eglCreateWindowSurface attrib_list):
+
+        "EGL_PRESENT_OPAQUE_EXT specifies the presentation opacity mode
+        of the window surface. If its value is EGL_TRUE, then the
+        surface's alpha channel (if any) will be ignored and considered
+        fully opaque. If its value is EGL_FALSE, then the surface's
+        alpha channel is respected by the compositor. The default value
+        of EGL_PRESENT_OPAQUE_EXT is EGL_FALSE."
+
+    Add to Table 3.5: Queryable surface attributes and types on p. 37
+
+        EGL_PRESENT_OPAQUE_EXT    boolean    Surface presentation opacity mode
+
+    Add following the second paragraph in section 3.6 on p. 39 (describing
+    eglQuerySurface):
+
+        "Querying EGL_PRESENT_OPAQUE_EXT returns the presentation
+        opacity mode of the surface. The presentation opacity mode of
+        window surfaces is specified in eglCreateWindowSurface. The
+        presentation opacity mode of pbuffer and pixmap surfaces is
+        always EGL_FALSE."
+
+    Add following after "which must be a valid native pixmap handle." in section 3.9.2 on
+    p. 53 (describing eglCopyBuffers):
+
+        "If attribute EGL_PRESENT_OPAQUE_EXT of surface has value of EGL_TRUE, then
+        an EGL_BAD_ACCESS error is returned."
+
+Issues
+
+    None
+
+Revision History
+
+    Version 1, 2021-08-08 (Eric Engestrom)
+      - Initial draft
+

--- a/extensions/EXT/EGL_EXT_present_opaque.txt
+++ b/extensions/EXT/EGL_EXT_present_opaque.txt
@@ -20,7 +20,7 @@ IP Status
 
 Status
 
-    Draft
+    Complete
 
 Version
 
@@ -79,9 +79,10 @@ Additions to Chapter 3 of the EGL 1.4 Specification (Rendering Surfaces)
         "EGL_PRESENT_OPAQUE_EXT specifies the presentation opacity mode
         of the window surface. If its value is EGL_TRUE, then the
         surface's alpha channel (if any) will be ignored and considered
-        fully opaque. If its value is EGL_FALSE, then the surface's
-        alpha channel is respected by the compositor. The default value
-        of EGL_PRESENT_OPAQUE_EXT is EGL_FALSE."
+        fully opaque. If its value is EGL_FALSE, then the compositor
+        doesn't change its behaviour, and considers the surface's alpha
+        channel the same way as if the extension wasn't implemented. The
+        default value of EGL_PRESENT_OPAQUE_EXT is EGL_FALSE."
 
     Add to Table 3.5: Queryable surface attributes and types on p. 37
 
@@ -107,6 +108,10 @@ Issues
     None
 
 Revision History
+
+    Version 2, 2021-08-17 (Eric Engestrom)
+      - Re-worded the compositor's behaviour for EGL_FALSE.
+      - Marked extension as Complete.
 
     Version 1, 2021-08-08 (Eric Engestrom)
       - Initial draft

--- a/index.php
+++ b/index.php
@@ -357,6 +357,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=145> <a href="extensions/EXT/EGL_EXT_config_select_group.txt">EGL_EXT_config_select_group</a>
 </li>
+<li value=146> <a href="extensions/EXT/EGL_EXT_present_opaque.txt">EGL_EXT_present_opaque</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -752,4 +752,9 @@ extension EGL_EXT_config_select_group {
     flags       public
     filename    extensions/EXT/EGL_EXT_config_select_group.txt
 }
-# Next free extension number: 146
+extension EGL_EXT_present_opaque {
+    number      146
+    flags       public
+    filename    extensions/EXT/EGL_EXT_present_opaque.txt
+}
+# Next free extension number: 147


### PR DESCRIPTION
This extension adds a new EGL surface attribute `EGL_PRESENT_OPAQUE_EXT` to indicate that the surface should be presented as opaque, disregarding any alpha channel if present.

/cc @cubanismo @fooishbar @flibitijibibo who were part of the discussion that lead to this extension.

checklist:
- [x] NVIDIA ack (for `EXT`)
- [ ] [Mesa implementation](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/12373)
- [ ] client implementation: [SDL](https://github.com/libsdl-org/SDL/pull/4646)