### PR TITLE
Reserve enum for EGL_OPENWF_DEVICE_EXT

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -14,7 +14,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 9581d004ff $ on $Git commit date: 2021-04-06 15:53:59 +0200 $
+** Khronos $Git commit SHA1: b35e89ca9a $ on $Git commit date: 2021-09-01 09:34:00 +0530 $
 */
 
 #include <EGL/eglplatform.h>
@@ -23,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20210802 */
+/* Generated on date 20210901 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: dc0b58dca5 $ on $Git commit date: 2021-06-25 01:58:50 +0200 $
+** Khronos $Git commit SHA1: b35e89ca9a $ on $Git commit date: 2021-09-01 09:34:00 +0530 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20210629
+#define EGL_EGLEXT_VERSION 20210901
 
 /* Generated C header for:
  * API: egl
@@ -700,6 +700,7 @@ EGLAPI EGLBoolean EGLAPIENTRY eglQueryDisplayAttribEXT (EGLDisplay dpy, EGLint a
 #ifndef EGL_EXT_device_openwf
 #define EGL_EXT_device_openwf 1
 #define EGL_OPENWF_DEVICE_ID_EXT          0x3237
+#define EGL_OPENWF_DEVICE_EXT             0x333D
 #endif /* EGL_EXT_device_openwf */
 
 #ifndef EGL_EXT_device_persistent_id

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -829,7 +829,8 @@
         <enum value="0x333A" name="EGL_COLOR_COMPONENT_TYPE_FIXED_EXT"/>
         <enum value="0x333B" name="EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT"/>
         <enum value="0x333C" name="EGL_DRM_MASTER_FD_EXT"/>
-            <unused start="0x333D" end="0x333E"/>
+        <enum value="0x333D" name="EGL_OPENWF_DEVICE_EXT"/>
+            <unused start="0x333E"/>
         <enum value="0x333F" name="EGL_GL_COLORSPACE_BT2020_LINEAR_EXT"/>
         <enum value="0x3340" name="EGL_GL_COLORSPACE_BT2020_PQ_EXT"/>
         <enum value="0x3341" name="EGL_SMPTE2086_DISPLAY_PRIMARY_RX_EXT"/>
@@ -2435,6 +2436,7 @@
         <extension name="EGL_EXT_device_openwf" supported="egl">
             <require>
                 <enum name="EGL_OPENWF_DEVICE_ID_EXT"/>
+                <enum name="EGL_OPENWF_DEVICE_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_device_query" supported="egl">


### PR DESCRIPTION
With revision #5 of EGL_EXT_device_openwf extension, EGL_OPENWF_DEVICE_EXT
attribute was added to the spec but it was somehow not added in egl.xml,
adding it now.