### PR TITLE
WIP: Add EGL_MESA_QUERY_RENDERER

### DIFF
--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 5a9a7e3fcb $ on $Git commit date: 2020-08-24 11:05:32 -0700 $
+** Khronos $Git commit SHA1: dc0b58dca5 $ on $Git commit date: 2021-06-25 01:58:50 +0200 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20201001
+#define EGL_EGLEXT_VERSION 20210629
 
 /* Generated C header for:
  * API: egl
@@ -994,6 +994,31 @@ EGLAPI EGLSurface EGLAPIENTRY eglCreatePixmapSurfaceHI (EGLDisplay dpy, EGLConfi
 #define EGL_NATIVE_BUFFER_MULTIPLANE_SEPARATE_IMG 0x3105
 #define EGL_NATIVE_BUFFER_PLANE_OFFSET_IMG 0x3106
 #endif /* EGL_IMG_image_plane_attribs */
+
+#ifndef EGL_MESA_QUERY_RENDERER
+#define EGL_MESA_QUERY_RENDERER 1
+#define EGL_RENDERER_VENDOR_ID_MESA       0x8F80
+#define EGL_RENDERER_DEVICE_ID_MESA       0x8F81
+#define EGL_RENDERER_VERSION_MESA         0x8F82
+#define EGL_RENDERER_ACCELERATED_MESA     0x8F83
+#define EGL_RENDERER_VIDEO_MEMORY_MESA    0x8F84
+#define EGL_RENDERER_UNIFIED_MEMORY_ARCHITECTURE_MESA 0x8F85
+#define EGL_RENDERER_PREFERRED_PROFILE_MESA 0x8F86
+#define EGL_RENDERER_OPENGL_CORE_PROFILE_VERSION_MESA 0x8F87
+#define EGL_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA 0x8F88
+#define EGL_RENDERER_OPENGL_ES_PROFILE_VERSION_MESA 0x8F89
+#define EGL_RENDERER_OPENGL_ES2_PROFILE_VERSION_MESA 0x8F8A
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYCURRENTRENDERERINTEGERMESAPROC) (EGLint attribute, EGLint *value);
+typedef const char *(EGLAPIENTRYP PFNEGLQUERYCURRENTRENDERERSTRINGMESAPROC) (EGLint attribute);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYRENDERERINTEGERMESAPROC) (EGLDisplay *dpy, EGLint renderer, EGLint attribute, EGLint *value);
+typedef const char *(EGLAPIENTRYP PFNEGLQUERYRENDERERSTRINGMESAPROC) (EGLDisplay *dpy, EGLint renderer, EGLint attribute);
+#ifdef EGL_EGLEXT_PROTOTYPES
+EGLAPI EGLBoolean EGLAPIENTRY eglQueryCurrentRendererIntegerMESA (EGLint attribute, EGLint *value);
+EGLAPI const char *EGLAPIENTRY eglQueryCurrentRendererStringMESA (EGLint attribute);
+EGLAPI EGLBoolean EGLAPIENTRY eglQueryRendererIntegerMESA (EGLDisplay *dpy, EGLint renderer, EGLint attribute, EGLint *value);
+EGLAPI const char *EGLAPIENTRY eglQueryRendererStringMESA (EGLDisplay *dpy, EGLint renderer, EGLint attribute);
+#endif
+#endif /* EGL_MESA_QUERY_RENDERER */
 
 #ifndef EGL_MESA_drm_image
 #define EGL_MESA_drm_image 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1046,6 +1046,20 @@
         <enum value="0x8F74" name="EGL_CLIENT_PIXMAP_POINTER_HI"/>
     </enums>
 
+    <enums namespace="EGL" start="0x8F80" end="0x8F8F" vendor="KHR">
+        <enum value="0x8F80" name="EGL_RENDERER_VENDOR_ID_MESA"/>
+        <enum value="0x8F81" name="EGL_RENDERER_DEVICE_ID_MESA"/>
+        <enum value="0x8F82" name="EGL_RENDERER_VERSION_MESA"/>
+        <enum value="0x8F83" name="EGL_RENDERER_ACCELERATED_MESA"/>
+        <enum value="0x8F84" name="EGL_RENDERER_VIDEO_MEMORY_MESA"/>
+        <enum value="0x8F85" name="EGL_RENDERER_UNIFIED_MEMORY_ARCHITECTURE_MESA"/>
+        <enum value="0x8F86" name="EGL_RENDERER_PREFERRED_PROFILE_MESA"/>
+        <enum value="0x8F87" name="EGL_RENDERER_OPENGL_CORE_PROFILE_VERSION_MESA"/>
+        <enum value="0x8F88" name="EGL_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA"/>
+        <enum value="0x8F89" name="EGL_RENDERER_OPENGL_ES_PROFILE_VERSION_MESA"/>
+        <enum value="0x8F8A" name="EGL_RENDERER_OPENGL_ES2_PROFILE_VERSION_MESA"/>
+    </enums>
+
     <!-- SECTION: EGL command definitions. -->
     <commands namespace="EGL">
         <command>
@@ -1973,6 +1987,36 @@
              <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
              <param><ptype>EGLImage</ptype> <name>image</name></param>
              <param><ptype>EGLSync</ptype> <name>sync</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglQueryDeviceBinaryEXT</name></proto>
+             <param><ptype>EGLDeviceEXT</ptype> <name>device</name></param>
+             <param><ptype>EGLint</ptype> <name>name</name></param>
+             <param><ptype>EGLint</ptype> <name>max_size</name></param>
+             <param>void *<name>value</name></param>
+             <param>EGLint *<name>size</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglQueryRendererIntegerMESA</name></proto>
+             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+             <param><ptype>EGLint</ptype> <name>renderer</name></param>
+             <param><ptype>EGLint</ptype> <name>attribute</name></param>
+             <param><ptype>EGLint</ptype> *<name>value</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglQueryCurrentRendererIntegerMESA</name></proto>
+             <param><ptype>EGLint</ptype> <name>attribute</name></param>
+             <param><ptype>EGLint</ptype> *<name>value</name></param>
+        </command>
+        <command>
+             <proto>const <ptype>char</ptype> *<name>eglQueryRendererStringMESA</name></proto>
+             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+             <param><ptype>EGLint</ptype> <name>renderer</name></param>
+             <param><ptype>EGLint</ptype> <name>attribute</name></param>
+        </command>
+        <command>
+             <proto>const <ptype>char</ptype> *<name>eglQueryCurrentRendererStringMESA</name></proto>
+             <param><ptype>EGLint</ptype> <name>attribute</name></param>
         </command>
     </commands>
 
@@ -3403,6 +3447,29 @@
         <extension name="EGL_EXT_device_query_name" supported="egl">
             <require>
                 <enum name="EGL_RENDERER_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_MESA_QUERY_RENDERER" supported="egl">
+            <require>
+                <enum name="EGL_RENDERER_VENDOR_ID_MESA"/>
+                <enum name="EGL_RENDERER_DEVICE_ID_MESA"/>
+                <enum name="EGL_RENDERER_VERSION_MESA"/>
+                <enum name="EGL_RENDERER_ACCELERATED_MESA"/>
+                <enum name="EGL_RENDERER_VIDEO_MEMORY_MESA"/>
+                <enum name="EGL_RENDERER_UNIFIED_MEMORY_ARCHITECTURE_MESA"/>
+                <enum name="EGL_RENDERER_PREFERRED_PROFILE_MESA"/>
+                <enum name="EGL_RENDERER_OPENGL_CORE_PROFILE_VERSION_MESA"/>
+                <enum name="EGL_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA"/>
+                <enum name="EGL_RENDERER_OPENGL_ES_PROFILE_VERSION_MESA"/>
+                <enum name="EGL_RENDERER_OPENGL_ES2_PROFILE_VERSION_MESA"/>
+                <command name="eglQueryCurrentRendererIntegerMESA"/>
+                <command name="eglQueryCurrentRendererStringMESA"/>
+                <command name="eglQueryRendererIntegerMESA"/>
+                <command name="eglQueryRendererStringMESA"/>
+                <type name="PFNEGLQUERYCURRENTRENDERERINTEGERMESAPROC"/>
+                <type name="PFNEGLQUERYCURRENTRENDERERSTRINGMESAPROC"/>
+                <type name="PFNEGLQUERYRENDERERINTEGERMESAPROC"/>
+                <type name="PFNEGLQUERYRENDERERSTRINGMESAPROC"/>
             </require>
         </extension>
     </extensions>

--- a/extensions/MESA/EGL_MESA_query_renderer.txt
+++ b/extensions/MESA/EGL_MESA_query_renderer.txt
@@ -1,0 +1,186 @@
+Name
+
+    MESA_query_renderer
+
+Name Strings
+
+    EGL_MESA_query_renderer
+
+Contact
+
+    Rob Clark      <robdclark 'at' gmail.com>
+    Nicolai Hähnle <Nicolai.Haehnle 'at' amd.com>
+
+Contributors
+
+    Veluri Mithun <velurimithun38 'at' gmail.com>
+
+Status
+
+    XXX - Not complete yet!!! (draft)
+
+Version
+
+    Version 1, 2018-08-24
+
+Number
+
+    EGL Extension ###
+
+Dependencies
+
+    EGL 1.0 is required.
+
+New Procedures and Functions
+
+    Bool eglQueryRendererIntegerMESA(EGLDisplay *dpy, int renderer,
+                                     int attribute, unsigned int *value);
+
+    Bool eglQueryCurrentRendererIntegerMESA(int attribute, unsigned int *value);
+
+    const char *eglQueryRendererStringMESA(EGLDisplay *dpy,int renderer,
+                                           int attribute);
+
+    const char *eglQueryCurrentRendererStringMESA(int attribute);
+
+Overview
+
+    In many situations, applications want to detect characteristics of a
+    rendering device before creating a context for that device.  Information
+    gathered at this stage may guide choices the application makes about
+    color depth, number of samples per-pixel, texture quality, and so on.
+    In addition, versions of supported APIs and implementation API
+    preference may also guide start-up decisions made by the application.
+    For example, one implementation may prefer vertex data be supplied using
+    methods only available in a compatibility profile, but another
+    implementation may only support the desired version in a core profile.
+
+    There are also cases where more than one renderer may be available per
+    display.  For example, there is typically a hardware implementation and
+    a software based implementation.  There are cases where an application
+    may want to pick one over the other.  One such situation is when the
+    software implementation supports more features than the hardware
+    implementation.  Another situation is when a particular version of the
+    hardware implementation is blacklisted due to known bugs.
+
+    This extension provides a mechanism for the application to query all of
+    the available renderers for a particular display. In addition, this 
+    extension provides a mechanism for applications to create contexts with 
+    respect to a specific renderer.
+
+IP Status
+
+    No IP claims
+
+New Tokens
+
+    Accepted as an <attribute> in eglQueryRendererIntegerMESA and
+    eglQueryCurrentRendererIntegerMESA:
+
+        EGL_RENDERER_VENDOR_ID_MESA                      0xXXXX
+        EGL_RENDERER_DEVICE_ID_MESA                      0xXXXX
+        EGL_RENDERER_VERSION_MESA                        0xXXXX
+        EGL_RENDERER_ACCELERATED_MESA                    0xXXXX
+        EGL_RENDERER_VIDEO_MEMORY_MESA                   0xXXXX
+        EGL_RENDERER_UNIFIED_MEMORY_ARCHITECTURE_MESA    0xXXXX
+        EGL_RENDERER_OPENGL_CORE_PROFILE_VERSION_MESA    0xXXXX
+        EGL_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA    0xXXXX
+
+    Accepted as an <attribute> in EGLQueryRendererStringMESA and
+    EGLQueryCurrentRendererStringMESA:
+
+        EGL_RENDERER_VENDOR_ID_MESA
+        EGL_RENDERER_DEVICE_ID_MESA
+
+Additions to the EGL 1.0 Specification
+
+    [Add the following to Section 3.3 of the EGL Versioning]
+
+    To obtain information about the available renderers for a particular
+    display,
+
+    Bool eglQueryRendererIntegerMESA(EGLDisplay *dpy, int renderer,
+                                     int attribute, unsigned int *value);
+
+    can be used.  The value for <attribute> will be returned in one or more
+    integers specified by <value>.  The values, data sizes, and descriptions
+    of each renderer attribute are listed in the table below.
+
+    EGL renderer attribute         number     description
+                                  of values
+    ----------------------        ---------   -----------
+    EGL_RENDERER_VENDOR_ID_MESA   1           PCI ID of the device vendor
+    EGL_RENDERER_DEVICE_ID_MESA   1           PCI ID of the device
+    EGL_RENDERER_VERSION_MESA     3           Major, minor, and patch level of
+                                              the renderer implementation
+    EGL_RENDERER_ACCELERATED_MESA 1           Boolean indicating whether or
+                                              not the renderer is hardware
+                                              accelerated
+    EGL_RENDERER_VIDEO_MEMORY_MESA 1          Number of megabytes of video
+                                              memory available to the renderer
+    EGL_RENDERER_UNIFIED_MEMORY_ARCHITECTURE_MESA
+                                  1           Boolean indicating whether or
+                                              not the renderer uses a unified
+                                              memory architecture or has
+                                              separate "on-card" and GART
+                                              memory.
+    EGL_RENDERER_OPENGL_CORE_PROFILE_VERSION_MESA
+                                  2           Maximum core profile major and
+                                              minor version supported by the
+                                              renderer
+    EGL_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA
+                                  2           Maximum compatibility profile
+                                              major and minor version
+                                              supported by the renderer
+
+    In the table, boolean attributes will have either the value 0 or 1.
+
+    EGL_RENDERER_OPENGL_CORE_PROFILE_VERSION_MESA,
+    EGL_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA,
+    each return <0, 0> in *value if no version of that profile is supported.
+
+    EGL_RENDERER_VENDOR_ID_MESA and EGL_RENDERER_DEVICE_ID_MESA may return
+    0xFFFFFFFF if the device does not have a PCI ID (because it is not a PCI
+    device) or if the PCI ID is not available.  In this case the application
+    should rely on the string query instead.
+
+    If <attribute> is not a recognized value, False is returned, but no EGL
+    error is generated.  Otherwise, True is returned.
+
+    String versions of some attributes may also be queried using
+
+    const char *eglQueryRendererStringMESA(EGLDisplay *dpy,int renderer,
+                                           int attribute);
+
+    The value for <attribute> will be returned in one or more
+    integers specified by <value>.  The values, data sizes, and descriptions
+    of each renderer attribute are listed in the table below.
+
+    EGL renderer attribute        description
+    ----------------------        -----------
+    EGL_RENDERER_VENDOR_ID_MESA   Name of the renderer provider.  This may
+                                  differ from the vendor name of the
+                                  underlying hardware.
+    EGL_RENDERER_DEVICE_ID_MESA   Name of the renderer.  This may differ from
+                                  the name of the underlying hardware (e.g.,
+                                  for a software renderer).
+
+    If <attribute> is not a recognized value, NULL is returned, but no EGL
+    error is generated.
+
+    The string returned for EGL_RENDERER_VENDOR_ID_MESA will have the same
+    format as the string that would be returned by glGetString of GL_VENDOR.
+    It may, however, have a different value.
+
+    The string returned for EGL_RENDERER_DEVICE_ID_MESA will have the same
+    format as the string that would be returned by glGetString of GL_RENDERER.
+    It may, however, have a different value.
+
+Issues
+
+    See also issues in GLX_MESA_query_renderer extension.
+
+Revision History
+
+    Version 1, 2018-08-24
+

--- a/index.php
+++ b/index.php
@@ -349,6 +349,11 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=141> <a href="extensions/EXT/EGL_EXT_platform_xcb.txt">EGL_EXT_platform_xcb</a>
 </li>
+</li>
+<li value=141> <a href="extensions/EXT/EGL_EXT_platform_xcb.txt">EGL_EXT_platform_xcb</a>
+</li>
+<li value=142> <a href="extensions/MESA/EGL_MESA_query_renderer.txt">EGL_MESA_query_renderer</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -732,4 +732,9 @@ extension EGL_EXT_platform_xcb {
     flags       public
     filename    extensions/EXT/EGL_EXT_platform_xcb.txt
 }
+extension EGL_MESA_QUERY_RENDERER {
+    number      142
+    flags       public
+    filename    extensions/MESA/EGL_MESA_query_renderer.txt
+}
 # Next free extension number: 142


### PR DESCRIPTION
Firefox [requested](https://gitlab.freedesktop.org/mesa/mesa/-/issues/2976) to have a way to query the device's vendor PCI ID and device PCI ID. A possible way to  
do these queries is by implementing EGL_MESA_QUERY_RENDERER as first proposed [here](https://lists.freedesktop.org/archives/mesa-dev/2018-November/208895.html)

A different extension `EGL_EXT_device_query_pci` to solve the same issue has also been proposed [here](https://gitlab.freedesktop.org/mesa/mesa/-/issues/2976#note_557557)