### PR TITLE
Update eglCreatePbufferSurface.xhtml

### DIFF
--- a/sdk/docs/man/html/eglCreatePbufferSurface.xhtml
+++ b/sdk/docs/man/html/eglCreatePbufferSurface.xhtml
@@ -117,7 +117,7 @@
                     <code class="constant">GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING</code>
                     value of <code class="constant">GL_LINEAR</code>. The default
                     value of <code class="constant">EGL_GL_COLORSPACE</code> is
-                    <code class="constant">EGL_GL_COLORSPACE_SRGB</code>.
+                    <code class="constant">EGL_GL_COLORSPACE_LINEAR</code>.
                 </p>
               <p>
                     Note that the <code class="constant">EGL_GL_COLORSPACE</code>


### PR DESCRIPTION
The default color space is EGL_GL_COLORSPACE_LINEAR not SRGB
