### PR TITLE
Add missing const keywords to eglStreamImageConsumerConnectNV

### DIFF
--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 8c62b915dd $ on $Git commit date: 2021-11-05 23:32:01 -0400 $
+** Khronos $Git commit SHA1: 992aa3914f $ on $Git commit date: 2021-11-23 18:20:45 +0100 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20211116
+#define EGL_EGLEXT_VERSION 20211210
 
 /* Generated C header for:
  * API: egl
@@ -1207,12 +1207,12 @@ EGLAPI EGLBoolean EGLAPIENTRY eglPostSubBufferNV (EGLDisplay dpy, EGLSurface sur
 #define EGL_STREAM_IMAGE_ADD_NV           0x3374
 #define EGL_STREAM_IMAGE_REMOVE_NV        0x3375
 #define EGL_STREAM_IMAGE_AVAILABLE_NV     0x3376
-typedef EGLBoolean (EGLAPIENTRYP PFNEGLSTREAMIMAGECONSUMERCONNECTNVPROC) (EGLDisplay dpy, EGLStreamKHR stream, EGLint num_modifiers, EGLuint64KHR *modifiers, EGLAttrib *attrib_list);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLSTREAMIMAGECONSUMERCONNECTNVPROC) (EGLDisplay dpy, EGLStreamKHR stream, EGLint num_modifiers, const EGLuint64KHR *modifiers, const EGLAttrib *attrib_list);
 typedef EGLint (EGLAPIENTRYP PFNEGLQUERYSTREAMCONSUMEREVENTNVPROC) (EGLDisplay dpy, EGLStreamKHR stream, EGLTime timeout, EGLenum *event, EGLAttrib *aux);
 typedef EGLBoolean (EGLAPIENTRYP PFNEGLSTREAMACQUIREIMAGENVPROC) (EGLDisplay dpy, EGLStreamKHR stream, EGLImage *pImage, EGLSync sync);
 typedef EGLBoolean (EGLAPIENTRYP PFNEGLSTREAMRELEASEIMAGENVPROC) (EGLDisplay dpy, EGLStreamKHR stream, EGLImage image, EGLSync sync);
 #ifdef EGL_EGLEXT_PROTOTYPES
-EGLAPI EGLBoolean EGLAPIENTRY eglStreamImageConsumerConnectNV (EGLDisplay dpy, EGLStreamKHR stream, EGLint num_modifiers, EGLuint64KHR *modifiers, EGLAttrib *attrib_list);
+EGLAPI EGLBoolean EGLAPIENTRY eglStreamImageConsumerConnectNV (EGLDisplay dpy, EGLStreamKHR stream, EGLint num_modifiers, const EGLuint64KHR *modifiers, const EGLAttrib *attrib_list);
 EGLAPI EGLint EGLAPIENTRY eglQueryStreamConsumerEventNV (EGLDisplay dpy, EGLStreamKHR stream, EGLTime timeout, EGLenum *event, EGLAttrib *aux);
 EGLAPI EGLBoolean EGLAPIENTRY eglStreamAcquireImageNV (EGLDisplay dpy, EGLStreamKHR stream, EGLImage *pImage, EGLSync sync);
 EGLAPI EGLBoolean EGLAPIENTRY eglStreamReleaseImageNV (EGLDisplay dpy, EGLStreamKHR stream, EGLImage image, EGLSync sync);

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1995,8 +1995,8 @@
              <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
              <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
              <param><ptype>EGLint</ptype> <name>num_modifiers</name></param>
-             <param><ptype>EGLuint64KHR</ptype> *<name>modifiers</name></param>
-             <param><ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
+             <param>const <ptype>EGLuint64KHR</ptype> *<name>modifiers</name></param>
+             <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
         </command>
         <command>
              <proto><ptype>EGLint</ptype> <name>eglQueryStreamConsumerEventNV</name></proto>

--- a/extensions/NV/EGL_NV_stream_consumer_eglimage.txt
+++ b/extensions/NV/EGL_NV_stream_consumer_eglimage.txt
@@ -56,8 +56,8 @@ New Procedures and Functions
                     EGLDisplay dpy,
                     EGLStreamKHR stream,
                     EGLint num_modifiers,
-                    EGLuint64KHR *modifiers,
-                    EGLAttrib* attrib_list);
+                    const EGLuint64KHR *modifiers,
+                    const EGLAttrib* attrib_list);
 
     EGLint eglQueryStreamConsumerEventNV(
                     EGLDisplay dpy,
@@ -149,8 +149,8 @@ EGL_KHR_stream extension with this:
                     EGLDisplay dpy,
                     EGLStreamKHR stream,
                     EGLint num_modifiers,
-                    EGLuint64KHR *modifiers,
-                    EGLAttrib* attrib_list);
+                    const EGLuint64KHR *modifiers,
+                    const EGLAttrib* attrib_list);
 
     to connect the EGLImage consumer to the <stream>. An EGLImage
     consumer allows image frames inserted in the stream to be received
@@ -337,6 +337,9 @@ Issues
 
 
 Revision History
+
+    #4  (December 10, 2021) Kyle Brenneman
+    	- Added the missing const modifier for input parameters
 
     #3  (November 27, 2019) Mukund Keshava
         - Refined some subsections with more details


### PR DESCRIPTION
The `modifiers` and `attrib_list` parameters to `eglStreamImageConsumerConnectNV` in EGL_NV_stream_consumer_eglimage are supposed to be input parameters, not output, but they're missing the const keyword.

This fixes the extension spec and the XML/header files.

Fixing the definition in eglext.h should be safe to change without breaking anything, since you can always pass a non-const value as a const parameter.