### PR TITLE
Fix extension/registry mismatch for EXT_surface_compression

### DIFF
--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 992aa3914f $ on $Git commit date: 2021-11-23 18:20:45 +0100 $
+** Khronos $Git commit SHA1: 330c97a53f $ on $Git commit date: 2022-03-22 03:57:27 -0500 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20211210
+#define EGL_EGLEXT_VERSION 20220323
 
 /* Generated C header for:
  * API: egl
@@ -967,9 +967,9 @@ EGLAPI EGLBoolean EGLAPIENTRY eglStreamConsumerOutputEXT (EGLDisplay dpy, EGLStr
 #define EGL_SURFACE_COMPRESSION_FIXED_RATE_10BPC_EXT 0x34BD
 #define EGL_SURFACE_COMPRESSION_FIXED_RATE_11BPC_EXT 0x34BE
 #define EGL_SURFACE_COMPRESSION_FIXED_RATE_12BPC_EXT 0x34BF
-typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYSUPPORTEDCOMPRESSIONRATESEXTPROC) (EGLDisplay dpy, EGLConfig *configs, const EGLAttrib *attrib_list, EGLint *rates, EGLint rate_size, EGLint *num_rates);
+typedef EGLBoolean (EGLAPIENTRYP PFNEGLQUERYSUPPORTEDCOMPRESSIONRATESEXTPROC) (EGLDisplay dpy, EGLConfig config, const EGLAttrib *attrib_list, EGLint *rates, EGLint rate_size, EGLint *num_rates);
 #ifdef EGL_EGLEXT_PROTOTYPES
-EGLAPI EGLBoolean EGLAPIENTRY eglQuerySupportedCompressionRatesEXT (EGLDisplay dpy, EGLConfig *configs, const EGLAttrib *attrib_list, EGLint *rates, EGLint rate_size, EGLint *num_rates);
+EGLAPI EGLBoolean EGLAPIENTRY eglQuerySupportedCompressionRatesEXT (EGLDisplay dpy, EGLConfig config, const EGLAttrib *attrib_list, EGLint *rates, EGLint rate_size, EGLint *num_rates);
 #endif
 #endif /* EGL_EXT_surface_compression */
 

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1729,7 +1729,7 @@
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglQuerySupportedCompressionRatesEXT</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
-            <param><ptype>EGLConfig</ptype> *<name>configs</name></param>
+            <param><ptype>EGLConfig</ptype> <name>config</name></param>
             <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
             <param><ptype>EGLint</ptype> *<name>rates</name></param>
             <param><ptype>EGLint</ptype> <name>rate_size</name></param>


### PR DESCRIPTION
EXT_surface_compression [defines eglQuerySupportedCompressionRatesEXT](https://github.com/KhronosGroup/EGL-Registry/blob/330c97a53fac1e61a066327b5036dc6eaa8d9e59/extensions/EXT/EGL_EXT_surface_compression.txt#L60) as taking an `EGLConfig config` argument.

However, [egl.xml defines it](https://github.com/KhronosGroup/EGL-Registry/blob/330c97a53fac1e61a066327b5036dc6eaa8d9e59/api/egl.xml#L1732) as taking `EGLConfig* configs`.

This function is meant to return a list of supported rates for a "combination of display and EGLConfig", so it seems like the declaration in egl.xml is the wrong one.

Original pull request for extension: https://github.com/KhronosGroup/EGL-Registry/pull/141