### PR TITLE
extensions: Correct a couple of extension types.

### DIFF
--- a/extensions/EXT/EGL_EXT_explicit_device.txt
+++ b/extensions/EXT/EGL_EXT_explicit_device.txt
@@ -31,7 +31,7 @@ Number
 
 Extension Type
 
-    EGL device extension
+    EGL client extension
 
 Dependencies
 

--- a/extensions/EXT/EGL_EXT_platform_device.txt
+++ b/extensions/EXT/EGL_EXT_platform_device.txt
@@ -29,7 +29,7 @@ Number
 
 Extension Type
 
-    EGL device extension
+    EGL client extension
 
 Dependencies
 


### PR DESCRIPTION
Minor fix for the EGL_EXT_explicit_device and EGL_EXT_platform_device specs, which are incorrectly labeled as device extensions. 

They both use EGLDevices, but they're listed via `eglQueryString` as client extensions.