### PR TITLE
Clarify version requirements of CreatePlatform{Window,Pixmap}Surface

### DIFF
--- a/sdk/docs/man/eglCreatePlatformPixmapSurface.xml
+++ b/sdk/docs/man/eglCreatePlatformPixmapSurface.xml
@@ -164,7 +164,7 @@
     </refsect1>
     <refsect1 xml:id="notes"><title>Notes</title>
         <para>
-            <code class="function">eglCreatnePlatformPixmapSurface</code> is supported only if
+            <code class="function">eglCreatePlatformPixmapSurface</code> is supported only if
             the EGL version is 1.5 or greater.
         </para>
         <para>

--- a/sdk/docs/man/eglCreatePlatformPixmapSurface.xml
+++ b/sdk/docs/man/eglCreatePlatformPixmapSurface.xml
@@ -164,22 +164,15 @@
     </refsect1>
     <refsect1 xml:id="notes"><title>Notes</title>
         <para>
+            <code class="function">eglCreatnePlatformPixmapSurface</code> is supported only if
+            the EGL version is 1.5 or greater.
+        </para>
+        <para>
             The <constant>EGL_MATCH_NATIVE_PIXMAP</constant> attribute
             of
             <citerefentry><refentrytitle>eglChooseConfig</refentrytitle></citerefentry>
             can be used to select a frame buffer configuration matching
             a specified native pixmap.
-        </para>
-        <para>
-            Attribute <constant>EGL_GL_COLORSPACE</constant> is supported
-            only if the EGL version is 1.5 or greater.
-        </para>
-        <para>
-            Attributes
-            <constant>EGL_VG_ALPHA_FORMAT</constant> and
-            <constant>EGL_VG_COLORSPACE</constant>, and the
-            corresponding attribute values, are supported only if the
-            EGL version is 1.2 or greater.
         </para>
         <!-- Might want to mention aliasing of EGL_VG_* -> EGL_* that occurred in EGL 1.3 -->
         <para>

--- a/sdk/docs/man/eglCreatePlatformWindowSurface.xml
+++ b/sdk/docs/man/eglCreatePlatformWindowSurface.xml
@@ -188,15 +188,8 @@
     </refsect1>
     <refsect1 xml:id="notes"><title>Notes</title>
         <para>
-            Attribute <constant>EGL_GL_COLORSPACE</constant> is supported
-            only if the EGL version is 1.5 or greater.
-        </para>
-        <para>
-            Attributes <constant>EGL_RENDER_BUFFER</constant>,
-            <constant>EGL_VG_ALPHA_FORMAT</constant>, and
-            <constant>EGL_VG_COLORSPACE</constant>, and the
-            corresponding attribute values, are supported only if the
-            EGL version is 1.2 or greater.
+            <code class="function">eglCreatePlatformWindowSurface</code> is supported only if
+            the EGL version is 1.5 or greater.
         </para>
         <!-- Might want to mention aliasing of EGL_VG_* -> EGL_* that occurred in EGL 1.3 -->
         <para>


### PR DESCRIPTION
Fixes: #169

These were folded into EGL 1.5 from EGL_EXT_platform_base. Make that clear, and remove
notes about parameter values newly available in EGL 1.4 and EGL 1.2

Signed-off-by: Christopher James Halse Rogers <raof@ubuntu.com>