### PR TITLE
Add EGL_NV_stream_consumer_eglimage_use_scanout_attrib ext.

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -14,7 +14,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 6fb1daea15 $ on $Git commit date: 2022-05-25 09:41:13 -0600 $
+** Khronos $Git commit SHA1: af97e2c27b $ on $Git commit date: 2022-09-20 03:01:16 -0700 $
 */
 
 #include <EGL/eglplatform.h>
@@ -23,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20220525 */
+/* Generated on date 20230210 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 6fb1daea15 $ on $Git commit date: 2022-05-25 09:41:13 -0600 $
+** Khronos $Git commit SHA1: af97e2c27b $ on $Git commit date: 2022-09-20 03:01:16 -0700 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20220525
+#define EGL_EGLEXT_VERSION 20230210
 
 /* Generated C header for:
  * API: egl
@@ -1222,6 +1222,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglStreamAcquireImageNV (EGLDisplay dpy, EGLStream
 EGLAPI EGLBoolean EGLAPIENTRY eglStreamReleaseImageNV (EGLDisplay dpy, EGLStreamKHR stream, EGLImage image, EGLSync sync);
 #endif
 #endif /* EGL_NV_stream_consumer_eglimage */
+
+#ifndef EGL_NV_stream_consumer_eglimage_use_scanout_attrib
+#define EGL_NV_stream_consumer_eglimage_use_scanout_attrib 1
+#define EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV 0x3378
+#endif /* EGL_NV_stream_consumer_eglimage_use_scanout_attrib */
 
 #ifndef EGL_NV_stream_consumer_gltexture_yuv
 #define EGL_NV_stream_consumer_gltexture_yuv 1

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -885,7 +885,8 @@
         <enum value="0x3375" name="EGL_STREAM_IMAGE_REMOVE_NV"/>
         <enum value="0x3376" name="EGL_STREAM_IMAGE_AVAILABLE_NV"/>
         <enum value="0x3377" name="EGL_DRM_RENDER_NODE_FILE_EXT"/>
-            <unused start="0x3378" end="0x339F"/>
+        <enum value="0x3378" name="EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV" />
+            <unused start="0x3379" end="0x339F"/>
     </enums>
 
     <enums namespace="EGL" start="0x33A0" end="0x33AF" vendor="ANGLE" comment="Reserved for Shannon Woods (Bug 13175)">
@@ -3531,6 +3532,11 @@
         <extension name="EGL_EXT_explicit_device" supported="egl">
             <require>
                 <enum name="EGL_DEVICE_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_NV_stream_consumer_eglimage_use_scanout_attrib" supported="egl">
+            <require>
+                <enum name="EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV"/>
             </require>
         </extension>
     </extensions>

--- a/extensions/NV/EGL_NV_stream_consumer_eglimage_use_scanout_attrib.txt
+++ b/extensions/NV/EGL_NV_stream_consumer_eglimage_use_scanout_attrib.txt
@@ -1,0 +1,93 @@
+Name
+
+    NV_stream_consumer_eglimage_use_scanout_attrib
+
+Name Strings
+
+    EGL_NV_stream_consumer_eglimage_use_scanout_attrib
+
+Contributors
+
+    Sruthik P
+    Daniel Koch
+    James Jones
+    Mukund Keshava
+
+Contacts
+
+    Sruthik P, NVIDIA(spatibandlla 'at' nvidia.com)
+
+Status
+
+    Draft
+
+Version
+
+    Version 2 - February 07, 2023
+
+Number
+
+    EGL Extension #149
+
+Extension Type
+
+    EGL display extension
+
+Dependencies
+
+    Requires the EGL_NV_stream_consumer_eglimage extension.
+
+    This extension is written against the wording of the EGL 1.5
+    Specification.
+
+Overview
+
+    This extension allows clients to specify to EGL implementations
+    if the images frames in the EGLStream acquired as EGLImages are
+    to be scanned out directly by display hardware.
+
+New Procedures and Functions
+
+    N/A
+
+New Tokens
+
+    Accepted as an attribute name in the <attrib_list> parameter of
+    eglStreamImageConsumerConnectNV:
+
+        EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV 0x3378
+
+Additions to section "3.10.2.2 EGLImage consumer"
+
+   Replace the paragraph that begins with "If not NULL, <attrib_list> points
+   to an array..." with the following:
+
+       If not NULL, <attrib_list> points to an array of name/value
+       pairs, terminated by EGL_NONE. Attributes accepted for <attrib_list>
+       are listed in Table 3.10.a, below.
+
+         Attribute Name                            Attribute Value(s)     Default Value
+         ----------------------------------------  -------------------    --------------
+         EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV  EGL_FALSE, EGL_TRUE    EGL_FALSE
+
+         Table 3.10.a: Legal EGLAttrib values for eglStreamImageConsumerConnectNV attrib_list parameter.
+
+   Append the list beginning with "On success, EGL_TRUE is returned..." with the following point:
+
+       - If EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV attribute is set to EGL_TRUE, the implementation
+         must ensure the image frames in the EGLStream are usable for scan out on the EGLDevice associated
+         with the EGLDisplay <dpy>.
+
+Issues
+
+   N/A
+
+Revision History
+
+    #2  (February 07, 2023) Sruthik P
+        - Update wording in section 3.10.2.2 to more strongly enforce the intent
+          of EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV.
+
+    #1  (February 06, 2023) Sruthik P
+        - Initial draft.
+

--- a/index.php
+++ b/index.php
@@ -361,6 +361,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=147> <a href="extensions/EXT/EGL_EXT_surface_compression.txt">EGL_EXT_surface_compression</a>
 </li>
+<li value=149> <a href="extensions/NV/EGL_NV_stream_consumer_eglimage_use_scanout_attrib.txt">EGL_NV_stream_consumer_eglimage_use_scanout_attrib</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/registry.tcl
+++ b/registry.tcl
@@ -767,4 +767,9 @@ extension EGL_EXT_explicit_device {
     flags       public
     filename    extensions/EXT/EGL_EXT_explicit_device.txt
 }
-# Next free extension number: 149
+extension EGL_NV_stream_consumer_eglimage_use_scanout_attrib {
+    number      149
+    flags       public
+    filename    extensions/NV/EGL_NV_stream_consumer_eglimage_use_scanout_attrib.txt
+}
+# Next free extension number: 150


### PR DESCRIPTION
This change adds a new EGL_NV_stream_consumer_eglimage_use_scanout_attrib extension.

EGL_NV_stream_consumer_eglimage_use_scanout_attrib adds a new attrib EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV that can be specified as part of eglStreamImageConsumerConnectNV().

Clients that intend to send EGLImages from the stream to display h/w for scanout can set this flag to allow for implementations to optimize the buffer allocations of the images for display access.