### PR TITLE
Change link in start.html to eglIntro.xhtml

### DIFF
--- a/sdk/docs/man/html/start.html
+++ b/sdk/docs/man/html/start.html
@@ -31,7 +31,7 @@
                     versions (1.2, 1.3, and 1.4). </p>
                 <p> A more detailed overview of EGL functionality and
                     technical concepts can be found in the <a
-                    target="pagedisplay" href="eglIntro.html">eglIntro</a>
+                    target="pagedisplay" href="eglIntro.xhtml">eglIntro</a>
                     page. </p>
             </div>
             <div class="refsect1" id="description">


### PR DESCRIPTION
/sdk/man/doc/html/start.html had a broken link which pointed to eglIntro.html. This PR fixes the link by changing it to eglIntro.xhtml