### PR TITLE
add fix for lxml import based on suggestion from lxml.de/tutorial.html

### DIFF
--- a/api/reg.py
+++ b/api/reg.py
@@ -4,7 +4,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io,os,re,string,sys
-from lxml import etree
+try:
+    # According to https://lxml.de/tutorial.html
+    #   if we are not using any lxml etree specific functions,
+    #   then xml.etree.ElementTree should behave the same way.
+    # Due to differences using MSYS on Windows, using xml.etree
+    #   instead was tested and seems fine.
+    from lxml import etree
+    print("running with lxml.etree")
+except ImportError:
+    import xml.etree.ElementTree as etree
+    print("running with Python's xml.etree.ElementTree")
+
 import subprocess
 
 def write(*args, **kwargs):


### PR DESCRIPTION
After installing the `lxml` dependency in MSYS on Windows using:
```
pacman -S python-lxml
```

..there was still an error:
```
$ make
```
```
python3 -B genheaders.py  -registry egl.xml EGL/egl.h
Traceback (most recent call last):
  File "EGL-Registry/api/genheaders.py", line 7, in <module>
    from reg import *
  File "EGL-Registry/api/reg.py", line 7, in <module>
    from lxml import etree
ImportError: No such process
make: *** [Makefile:17: EGL/egl.h] Error 1
```
![image](https://github.com/KhronosGroup/EGL-Registry/assets/25648730/fb6ade18-4dd4-4e09-87c4-9336eb3685d2)

It appears as if these may be well known because this website presented an alternative for those not depending explicitly on functions included in the `lxml` implementation of `etree`, found here:
https://lxml.de/tutorial.html

Upon making this change..
![image](https://github.com/KhronosGroup/EGL-Registry/assets/25648730/d4f58f8b-6fb2-404b-a49e-a2bcc953fe2d)

..the ability to use `make` out of the box was restored:
![image](https://github.com/KhronosGroup/EGL-Registry/assets/25648730/d38c3131-107f-4dd1-a971-3530a9489095)


This pull request addresses this. A visual inspection of `reg.py` on surface level looks to not use any `lxml.etree` specific functions.