### PR TITLE
Correct EGL_EXT_config_select_group's type to be a display extension

### DIFF
--- a/extensions/EXT/EGL_EXT_config_select_group.txt
+++ b/extensions/EXT/EGL_EXT_config_select_group.txt
@@ -30,7 +30,7 @@ Number
 
 Extension Type
 
-    EGL client extension
+    EGL display extension
 
 Dependencies
 
@@ -97,6 +97,9 @@ Issues
     None
 
 Revision History
+
+    Version 5, 2024-05-09 (Kyle Brenneman)
+        - Corrected extension type to display extension.
 
     Version 4, 2021-06-24 (Robert Mader)
         - Moved to EXT, changed enum value to 0x34C0.


### PR DESCRIPTION
Because `EGL_EXT_config_select_group` only affects the behavior of `eglChooseConfig` (which takes and is dispatched based on an `EGLDisplay`), it's a display extension, not a client extension.