### PR TITLE
Use ElementTree instead of lxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,9 @@ This section is not complete (see https://github.com/KhronosGroup/EGL-Registry/i
 
 To validate the XML and build the headers you will need at least GNU make,
 'jing' for the 'make validate' step (https://relaxng.org/jclark/jing.html),
-and Python 3.5 and the lxml.etree Python library
-(https://pypi.org/project/lxml/) for the 'make' step. The 'make tests' step
-requires whatever the C and C++ compilers configured for GNU make are,
-usually gcc and g++.
+and Python 3.5 for the 'make' step.
+The 'make tests' step requires whatever the C and C++ compilers configured
+for GNU make are, usually gcc and g++.
 
 All of these components are available prepackaged for major Linux
 distributions and for the Windows 10 Debian WSL.

--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -14,7 +14,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: f4cc936b88 $ on $Git commit date: 2023-12-16 01:21:49 -0500 $
+** Khronos $Git commit SHA1: d4f0a976e4 $ on $Git commit date: 2024-05-10 08:42:40 -0600 $
 */
 
 #include <EGL/eglplatform.h>
@@ -23,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20231215 */
+/* Generated on date 20240513 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: f4cc936b88 $ on $Git commit date: 2023-12-16 01:21:49 -0500 $
+** Khronos $Git commit SHA1: d4f0a976e4 $ on $Git commit date: 2024-05-10 08:42:40 -0600 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20231215
+#define EGL_EGLEXT_VERSION 20240513
 
 /* Generated C header for:
  * API: egl

--- a/api/reg.py
+++ b/api/reg.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io,os,re,string,sys
-from lxml import etree
+import xml.etree.ElementTree as etree
 import subprocess
 
 def write(*args, **kwargs):

--- a/api/reg.py
+++ b/api/reg.py
@@ -14,7 +14,7 @@ def write(*args, **kwargs):
     file.write(end)
 
 # noneStr - returns string argument, or "" if argument is None.
-# Used in converting lxml Elements into text.
+# Used in converting ElementTree Elements into text.
 #   str - string to convert
 def noneStr(str):
     if (str):
@@ -75,7 +75,7 @@ def matchAPIProfile(api, profile, elem):
 #   required - should this feature be defined during header generation
 #     (has it been removed by a profile or version)?
 #   declared - has this feature been defined already?
-#   elem - lxml.etree Element for this feature
+#   elem - ElementTree Element for this feature
 #   resetState() - reset required/declared to initial values. Used
 #     prior to generating a new API interface.
 class BaseInfo:
@@ -462,7 +462,7 @@ class COutputGenerator(OutputGenerator):
         # For typedefs, add (APIENTRYP <name>) around the name and
         #   use the PFNGLCMDNAMEPROC nameng convention.
         # Done by walking the tree for <proto> element by element.
-        # lxml.etree has elem.text followed by (elem[i], elem[i].tail)
+        # ElementTree has elem.text followed by (elem[i], elem[i].tail)
         #   for each child element and any following text
         # Leading text
         pdecl += noneStr(proto.text)


### PR DESCRIPTION
Alternate replacement for #198 since there's no actual need for lxml functionality or semantics in this repo.