### PR TITLE
extensions: Add EGL_ANDROID_telemetry_hint

### DIFF
--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -14,7 +14,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: f4cc936b88 $ on $Git commit date: 2023-12-16 01:21:49 -0500 $
+** Khronos $Git commit SHA1: 4a98615083 $ on $Git commit date: 2024-07-06 20:01:49 +0100 $
 */
 
 #include <EGL/eglplatform.h>
@@ -23,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20231215 */
+/* Generated on date 20240706 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/egl.h
+++ b/api/EGL/egl.h
@@ -14,7 +14,7 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 4a98615083 $ on $Git commit date: 2024-07-06 20:01:49 +0100 $
+** Khronos $Git commit SHA1: 402ce7f591 $ on $Git commit date: 2024-07-09 16:33:12 +0000 $
 */
 
 #include <EGL/eglplatform.h>
@@ -23,7 +23,7 @@ extern "C" {
 #define EGL_EGL_PROTOTYPES 1
 #endif
 
-/* Generated on date 20240706 */
+/* Generated on date 20240710 */
 
 /* Generated C header for:
  * API: egl

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: f4cc936b88 $ on $Git commit date: 2023-12-16 01:21:49 -0500 $
+** Khronos $Git commit SHA1: 4a98615083 $ on $Git commit date: 2024-07-06 20:01:49 +0100 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20231215
+#define EGL_EGLEXT_VERSION 20240706
 
 /* Generated C header for:
  * API: egl
@@ -550,6 +550,11 @@ EGLAPI EGLBoolean EGLAPIENTRY eglPresentationTimeANDROID (EGLDisplay dpy, EGLSur
 #define EGL_ANDROID_recordable 1
 #define EGL_RECORDABLE_ANDROID            0x3142
 #endif /* EGL_ANDROID_recordable */
+
+#ifndef EGL_ANDROID_telemetry_hint
+#define EGL_ANDROID_telemetry_hint 1
+#define EGL_ANDROID_TELEMETRY_HINT        0x9001
+#endif /* EGL_ANDROID_telemetry_hint */
 
 #ifndef EGL_ANGLE_d3d_share_handle_client_buffer
 #define EGL_ANGLE_d3d_share_handle_client_buffer 1

--- a/api/EGL/eglext.h
+++ b/api/EGL/eglext.h
@@ -14,12 +14,12 @@ extern "C" {
 ** used to make the header, and the header can be found at
 **   http://www.khronos.org/registry/egl
 **
-** Khronos $Git commit SHA1: 4a98615083 $ on $Git commit date: 2024-07-06 20:01:49 +0100 $
+** Khronos $Git commit SHA1: 402ce7f591 $ on $Git commit date: 2024-07-09 16:33:12 +0000 $
 */
 
 #include <EGL/eglplatform.h>
 
-#define EGL_EGLEXT_VERSION 20240706
+#define EGL_EGLEXT_VERSION 20240710
 
 /* Generated C header for:
  * API: egl
@@ -553,7 +553,7 @@ EGLAPI EGLBoolean EGLAPIENTRY eglPresentationTimeANDROID (EGLDisplay dpy, EGLSur
 
 #ifndef EGL_ANDROID_telemetry_hint
 #define EGL_ANDROID_telemetry_hint 1
-#define EGL_ANDROID_TELEMETRY_HINT        0x9001
+#define EGL_TELEMETRY_HINT_ANDROID        0x3570
 #endif /* EGL_ANDROID_telemetry_hint */
 
 #ifndef EGL_ANGLE_d3d_share_handle_client_buffer

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1089,6 +1089,11 @@
         <unused start="0x3560" end="0x356F"/>
     </enums>
 
+    <enums namespace="EGL" start="0x3570" end="0x357F" vendor="Google" comment="Reserved for Tom Murphy (Khronos bug ...)">
+        <enum value="0x3570" name="EGL_ANDROID_TELEMETRY_HINT"/>
+            <unused start="0x3571" end="0x357F"/>
+    </enums>
+
 <!-- Please remember that new enumerant allocations must be obtained by
      request to the Khronos API registrar (see comments at the top of this
      file) File requests in the Khronos Bugzilla, EGL project, Registry
@@ -1108,11 +1113,6 @@
         <enum value="0x8F72" name="EGL_COLOR_RGBA_HI"/>
         <enum value="0x8F73" name="EGL_COLOR_ARGB_HI"/>
         <enum value="0x8F74" name="EGL_CLIENT_PIXMAP_POINTER_HI"/>
-    </enums>
-
-    <enums namespace="EGL" start="0x3570" end="0x3580" vendor="Google" comment="Reserved for Tom Murphy (Khronos bug ...)">
-        <enum value="0x3570" name="EGL_ANDROID_TELEMETRY_HINT"/>
-            <unused start="0x3571" end="0x3580"/>
     </enums>
 
     <!-- SECTION: EGL command definitions. -->

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1090,7 +1090,7 @@
     </enums>
 
     <enums namespace="EGL" start="0x3570" end="0x357F" vendor="Google" comment="Reserved for Tom Murphy (Khronos bug ...)">
-        <enum value="0x3570" name="EGL_ANDROID_TELEMETRY_HINT"/>
+        <enum value="0x3570" name="EGL_TELEMETRY_HINT_ANDROID"/>
             <unused start="0x3571" end="0x357F"/>
     </enums>
 
@@ -2414,7 +2414,7 @@
         <extension name="EGL_ANDROID_GLES_layers" supported="egl"/>
         <extension name="EGL_ANDROID_telemetry_hint" supported="egl">
             <require>
-                <enum name="EGL_ANDROID_TELEMETRY_HINT"/>
+                <enum name="EGL_TELEMETRY_HINT_ANDROID"/>
             </require>
         </extension>
         <extension name="EGL_ANGLE_d3d_share_handle_client_buffer" supported="egl">

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1089,7 +1089,7 @@
         <unused start="0x3560" end="0x356F"/>
     </enums>
 
-    <enums namespace="EGL" start="0x3570" end="0x357F" vendor="Google" comment="Reserved for Tom Murphy (Khronos bug ...)">
+    <enums namespace="EGL" start="0x3570" end="0x357F" vendor="Google" comment="Reserved for Tom Murphy (EGL-Registry pull #204)">
         <enum value="0x3570" name="EGL_TELEMETRY_HINT_ANDROID"/>
             <unused start="0x3571" end="0x357F"/>
     </enums>

--- a/api/egl.xml
+++ b/api/egl.xml
@@ -1098,8 +1098,8 @@
 
 <!-- Reservable for future use. To generate a new range, allocate multiples
      of 16 starting at the lowest available point in this block. -->
-    <enums namespace="EGL" start="0x3570" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
-            <unused start="0x3570" end="0x3FFF"/>
+    <enums namespace="EGL" start="0x3580" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
+            <unused start="0x3580" end="0x3FFF"/>
     </enums>
 
     <enums namespace="EGL" start="0x8F70" end="0x8F7F" vendor="HI" comment="For Mark Callow, Khronos bug 4055. Shared with GL.">
@@ -1108,6 +1108,11 @@
         <enum value="0x8F72" name="EGL_COLOR_RGBA_HI"/>
         <enum value="0x8F73" name="EGL_COLOR_ARGB_HI"/>
         <enum value="0x8F74" name="EGL_CLIENT_PIXMAP_POINTER_HI"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3570" end="0x3580" vendor="Google" comment="Reserved for Tom Murphy (Khronos bug ...)">
+        <enum value="0x3570" name="EGL_ANDROID_TELEMETRY_HINT"/>
+            <unused start="0x3571" end="0x3580"/>
     </enums>
 
     <!-- SECTION: EGL command definitions. -->
@@ -2407,6 +2412,11 @@
             </require>
         </extension>
         <extension name="EGL_ANDROID_GLES_layers" supported="egl"/>
+        <extension name="EGL_ANDROID_telemetry_hint" supported="egl">
+            <require>
+                <enum name="EGL_ANDROID_TELEMETRY_HINT"/>
+            </require>
+        </extension>
         <extension name="EGL_ANGLE_d3d_share_handle_client_buffer" supported="egl">
             <require>
                 <enum name="EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE"/>

--- a/extensions/ANDROID/EGL_ANDROID_telemetry_hint.txt
+++ b/extensions/ANDROID/EGL_ANDROID_telemetry_hint.txt
@@ -1,0 +1,68 @@
+Name
+
+    ANDROID_telemetry_hint
+
+Name Strings
+
+    EGL_ANDROID_telemetry_hint
+
+Contributors
+
+    Tom Murphy
+
+Contact
+
+    Tom Murphy, Google Inc. (tomnom 'at' google.com)
+
+Status
+
+    Draft
+
+Version
+
+    Version 1, July 6, 2024
+
+Number
+
+    EGL Extension #153
+
+Dependencies:
+
+    None.
+
+Overview
+
+    The telemetry of Android OpenGL ES can be enhanced by including information
+    about the purpose for which a context is created. This extension introduces
+    a new EGLConfig attribute that indicates the intended use of the context.
+    By doing so, OpenGL telemetry can be separated based on which library
+    created the context.
+
+    This extension is specifically designed for use by Android Platform
+    developers. Consequently, we have not defined the values associated with
+    EGL_ANDROID_TELEMETRY_HINT within this specification. Instead, these values
+    are defined in Android's telemetry header files, allowing us to easily add
+    new telemetry hints without cluttering this specification.
+
+New Types
+
+    None.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    Accepted by the <attrib_list> parameter of eglCreateContext:
+
+    EGL_ANDROID_TELEMETRY_HINT                      0x9001
+
+Issues
+
+    None.
+
+Revision History
+
+#1 (Tom Murphy, July 6, 2024)
+    - Initial draft.

--- a/index.php
+++ b/index.php
@@ -370,6 +370,8 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=151> <a href="extensions/QNX/EGL_QNX_image_native_buffer.txt">EGL_QNX_image_native_buffer</a>
 </li>
+<li value=153> <a href="extensions/QNX/EGL_ANDROID_telemetry_hint.txt">EGL_ANDROID_telemetry_hint</a>
+</li>
 </ol>
 
 <h6> Providing Feedback on the Registry </h6>

--- a/index.php
+++ b/index.php
@@ -370,7 +370,7 @@ include_once("../../assets/static_pages/khr_page_top.php");
 </li>
 <li value=151> <a href="extensions/QNX/EGL_QNX_image_native_buffer.txt">EGL_QNX_image_native_buffer</a>
 </li>
-<li value=153> <a href="extensions/QNX/EGL_ANDROID_telemetry_hint.txt">EGL_ANDROID_telemetry_hint</a>
+<li value=153> <a href="extensions/ANDROID/EGL_ANDROID_telemetry_hint.txt">EGL_ANDROID_telemetry_hint</a>
 </li>
 </ol>
 

--- a/registry.tcl
+++ b/registry.tcl
@@ -788,4 +788,9 @@ extension EXT_query_reset_notification_strategy {
     flags       public
     filename    extensions/EXT/EGL_EXT_query_reset_notification_strategy.txt
 }
-# Next free extension number: 153
+extension EGL_ANDROID_telemetry_hint {
+    number      153
+    flags       public
+    filename    extensions/EXT/EGL_ANDROID_telemetry_hint.txt
+}
+# Next free extension number: 154


### PR DESCRIPTION
Add a new EGL_TELEMETRY_HINT_ANDROID to help Android telemetry disguise between OpenGL contexts.