### PR TITLE
EGL_{EXT,KHR}_platform_wayland: use actual types

### DIFF
--- a/extensions/EXT/EGL_EXT_platform_wayland.txt
+++ b/extensions/EXT/EGL_EXT_platform_wayland.txt
@@ -20,7 +20,7 @@ Status
 
 Version
 
-    Version 4, 2014-03-10
+    Version 5, 2026-04-03
 
 Number
 
@@ -79,7 +79,7 @@ New Behavior
 
     To obtain an on-screen rendering surface from a Wayland window, call
     eglCreatePlatformWindowSurfaceEXT with a <dpy> that belongs to Wayland and
-    a <native_window> that points to a `struct wl_egl_surface`.
+    a <native_window> that points to a `struct wl_egl_window`.
 
     It is not valid to call eglCreatePlatformPixmapSurfaceEXT with a <dpy>
     that belongs to Wayland. Any such call fails and generates
@@ -109,6 +109,10 @@ Issues
        interest in Wayland.
 
 Revision History
+
+    Version 5, 2026-04-03 (Lennart Jablonka)
+        - Replace `struct wl_egl_surface` by `struct wl_egl_window`,
+          as is implemented.
 
     Version 4, 2014-03-10(Chad Versace)
         - Change resolution of issue #1 from "no" to "yes". Now

--- a/extensions/KHR/EGL_KHR_platform_wayland.txt
+++ b/extensions/KHR/EGL_KHR_platform_wayland.txt
@@ -23,7 +23,7 @@ Status
 
 Version
 
-    Version 2, 2014/02/18
+    Version 4, 2026/04/03
 
 Number
 
@@ -82,7 +82,7 @@ New Behavior
 
     To obtain an on-screen rendering surface from a Wayland window, call
     eglCreatePlatformWindowSurface with a <dpy> that belongs to Wayland and
-    a <native_window> that points to a `struct wl_egl_surface`.
+    a <native_window> that points to a `struct wl_egl_window`.
 
     It is not valid to call eglCreatePlatformPixmapSurface with a <dpy> that
     belongs to Wayland. Any such call fails and generates an
@@ -107,6 +107,10 @@ Issues
        RESOLVED. No. Wayland has no pixmap type.
 
 Revision History
+    Version 4, 2026/04/03 (Lennart Jablonka)
+        - Replace `struct wl_egl_surface` by `struct wl_egl_window`,
+          as is implemented.
+
     Version 3, 2022/07/14 (Kirill Chibisov)
         - Clarify EGLSurface back buffer locking behavior with regards to
           rendering and surface querying operations.


### PR DESCRIPTION
As far as I can tell, the type actually used in wayland-egl was always called struct wl_egl_window.  This is also already reflected in api/EGL/eglplatform.h's definition of EGLNativeWindowType.